### PR TITLE
Stops scanning and flushes serial device on destruction, resolves #23

### DIFF
--- a/libsweep/examples/example.c
+++ b/libsweep/examples/example.c
@@ -62,6 +62,10 @@ int main() {
     sweep_scan_destruct(scan);
   }
 
+  // Stop capturing scans
+  sweep_device_stop_scanning(sweep, &error);
+  check(error);
+
   // Shut down and cleanup Sweep device
   sweep_device_destruct(sweep);
   return EXIT_SUCCESS;

--- a/libsweep/examples/example.cc
+++ b/libsweep/examples/example.cc
@@ -17,6 +17,9 @@ int main() try {
       std::cout << "angle " << sample.angle << " distance " << sample.distance << " strength " << sample.signal_strength << "\n";
     }
   }
+
+  device.stop_scanning();
+
 } catch (const sweep::device_error& e) {
   std::cerr << "Error: " << e.what() << std::endl;
 }

--- a/libsweep/examples/viewer.cc
+++ b/libsweep/examples/viewer.cc
@@ -113,6 +113,9 @@ int main() try {
       pointCloud = std::move(localPointCloud);
     }
   }
+
+  device.stop_scanning();
+
 } catch (const sweep::device_error& e) {
   std::cerr << "Error: " << e.what() << std::endl;
 }

--- a/libsweep/serial_unix.c
+++ b/libsweep/serial_unix.c
@@ -359,6 +359,10 @@ sweep_serial_device_s sweep_serial_device_construct(const char* port, int32_t bi
 void sweep_serial_device_destruct(sweep_serial_device_s serial) {
   SWEEP_ASSERT(serial);
 
+  sweep_serial_error_s ignore = NULL;
+  sweep_serial_device_flush(serial, &ignore);
+  (void)ignore; // nothing we can do here
+
   free(serial);
 }
 

--- a/libsweep/sweep.c
+++ b/libsweep/sweep.c
@@ -95,6 +95,10 @@ sweep_device_s sweep_device_construct(const char* port, int32_t bitrate, sweep_e
 void sweep_device_destruct(sweep_device_s device) {
   SWEEP_ASSERT(device);
 
+  sweep_error_s ignore = NULL;
+  sweep_device_stop_scanning(device, &ignore);
+  (void)ignore; // nothing we can do here
+
   sweep_serial_device_destruct(device->serial);
 
   free(device);


### PR DESCRIPTION
Calling the stop function on the user-side is not really necessary as we're doing it on device destruction anyway if it wasn't done so far. It's more to get users familiar with the symmetric API.

I confirmed #23 being an issue with the recent units and this changeset fixing it for me.

@dcyoung can you confirm? Edit: confirmed working in issue.