### PR TITLE
Changed signal strength storage format to match all other Scanse docs…

### DIFF
--- a/libsweep/README.md
+++ b/libsweep/README.md
@@ -218,7 +218,7 @@ Returns the distance in centi-meter for the `sample`th sample in the `sweep_scan
 int32_t sweep_scan_get_signal_strength(sweep_scan_s scan, int32_t sample)
 ```
 
-Returns the signal strength (1 low -- 100 high) for the `sample`th sample in the `sweep_scan_s`.
+Returns the signal strength (0 low -- 255 high) for the `sample`th sample in the `sweep_scan_s`.
 
 
 ### License

--- a/libsweep/examples/README.md
+++ b/libsweep/examples/README.md
@@ -14,7 +14,7 @@ To build:
     mkdir build
     cd build
     cmake ..
-    make
+    cmake --build .
 ```
 
 **Note:** the viewer requires SFML2 to be installed.

--- a/libsweep/examples/README.md
+++ b/libsweep/examples/README.md
@@ -14,7 +14,7 @@ To build:
     mkdir build
     cd build
     cmake ..
-    cmake --build .
+    make
 ```
 
 **Note:** the viewer requires SFML2 to be installed.

--- a/libsweep/examples/example.c
+++ b/libsweep/examples/example.c
@@ -52,10 +52,11 @@ int main() {
     // For each sample in a full 360 degree scan print angle and distance.
     // In case you're doing expensive work here consider using a decoupled producer / consumer pattern.
     for (int32_t n = 0; n < sweep_scan_get_number_of_samples(scan); ++n) {
-      int32_t angle = sweep_scan_get_angle(scan, n);
+      // convert milli-degree (int) to degrees (float)
+      float angle = sweep_scan_get_angle(scan, n) / 1000.f;
       int32_t distance = sweep_scan_get_distance(scan, n);
       int32_t signal = sweep_scan_get_signal_strength(scan, n);
-      fprintf(stdout, "Angle %" PRId32 ", Distance %" PRId32 ", Signal Strength: %" PRId32 "\n", angle, distance, signal);
+      fprintf(stdout, "n: %d, Angle: %f, Distance: %d, Signal Strength: %d\n", n, angle, distance, signal);
     }
 
     // Cleanup scan response

--- a/libsweep/examples/example.cc
+++ b/libsweep/examples/example.cc
@@ -14,7 +14,8 @@ int main() try {
     const sweep::scan scan = device.get_scan();
 
     for (const sweep::sample& sample : scan.samples) {
-      std::cout << "angle " << sample.angle << " distance " << sample.distance << " strength " << sample.signal_strength << "\n";
+      std::cout << "Angle: " << sample.angle / 1000.f << ", Distance: " << sample.distance << ", Strength "
+                << sample.signal_strength << "\n";
     }
   }
 

--- a/libsweep/examples/example.cc
+++ b/libsweep/examples/example.cc
@@ -14,7 +14,7 @@ int main() try {
     auto scan = device.get_scan();
 
     for (auto sample : scan.samples) {
-      std::cout << "angle " << sample.angle << " distance " << sample.distance << " strength " << sample.signal_strength << "\n";
+      std::cout << "Angle: " << sample.angle/1000.f << ", Distance: " << sample.distance << ", Signal Strength: " << sample.signal_strength << "\n";
     }
   }
 

--- a/libsweep/examples/viewer.cc
+++ b/libsweep/examples/viewer.cc
@@ -101,7 +101,7 @@ int main() try {
 
       // Base transparency on signal strength
       auto color = kColorDenim;
-      color.a = (sample.signal_strength / 100.0f) * 255.0f;
+      color.a = sample.signal_strength;
       point.setFillColor(color);
 
       localPointCloud.push_back(std::move(point));

--- a/libsweep/sweep.c
+++ b/libsweep/sweep.c
@@ -23,18 +23,18 @@ typedef struct sweep_device {
  * Struct: sweep_scan
  * ------------------
  * Contains the data for sensor readings in a scan
- * 
+ *
  *  angle: array of azimuth values (1 for each reading)
  *        (in millidegrees, ie: 241.375deg stored as 241375millideg)
  *  distance: array of range values (1 for each reading)
  *        (in centimeters)
  *  signal_strength: array of signal strength values (1 for each reading)
  *        (integer values between 0:255, higher is better)
- *  count: number of sensor readings in the scan 
+ *  count: number of sensor readings in the scan
  */
 typedef struct sweep_scan {
-  int32_t angle[SWEEP_MAX_SAMPLES]; // in millidegrees 
-  int32_t distance[SWEEP_MAX_SAMPLES]; // in cm
+  int32_t angle[SWEEP_MAX_SAMPLES];           // in millidegrees
+  int32_t distance[SWEEP_MAX_SAMPLES];        // in cm
   int32_t signal_strength[SWEEP_MAX_SAMPLES]; // range 0:255
   int32_t count;
 } sweep_scan;
@@ -242,11 +242,11 @@ sweep_scan_s sweep_device_get_scan(sweep_device_s device, sweep_error_s* error) 
   for (int32_t it = 0; it < last - first; ++it) {
     // convert the angle from its compact serial format to a float value in degrees
     // then convert from degrees to milli-degrees, and store it in a signed int32_t
-    out->angle[it] = (int32_t) (sweep_protocol_u16_to_f32(responses[first + it].angle) * 1000.f);
+    out->angle[it] = (int32_t)(sweep_protocol_u16_to_f32(responses[first + it].angle) * 1000.f);
     // store the distance in a signed int32
-    out->distance[it] = (int32_t) responses[first + it].distance;
+    out->distance[it] = (int32_t)responses[first + it].distance;
     // store the signal strength in a signed int32
-    out->signal_strength[it] = (int32_t) responses[first + it].signal_strength;
+    out->signal_strength[it] = (int32_t)responses[first + it].signal_strength;
   }
 
   return out;

--- a/libsweep/sweep.c
+++ b/libsweep/sweep.c
@@ -19,10 +19,23 @@ typedef struct sweep_device {
 
 #define SWEEP_MAX_SAMPLES 4096
 
+/*
+ * Struct: sweep_scan
+ * ------------------
+ * Contains the data for sensor readings in a scan
+ * 
+ *  angle: array of azimuth values (1 for each reading)
+ *        (in millidegrees, ie: 241.375deg stored as 241375millideg)
+ *  distance: array of range values (1 for each reading)
+ *        (in centimeters)
+ *  signal_strength: array of signal strength values (1 for each reading)
+ *        (integer values between 0:255, higher is better)
+ *  count: number of sensor readings in the scan 
+ */
 typedef struct sweep_scan {
-  int32_t angle[SWEEP_MAX_SAMPLES];
-  int32_t distance[SWEEP_MAX_SAMPLES];
-  int32_t signal_strength[SWEEP_MAX_SAMPLES];
+  int32_t angle[SWEEP_MAX_SAMPLES]; // in millidegrees 
+  int32_t distance[SWEEP_MAX_SAMPLES]; // in cm
+  int32_t signal_strength[SWEEP_MAX_SAMPLES]; // range 0:255
   int32_t count;
 } sweep_scan;
 
@@ -227,9 +240,13 @@ sweep_scan_s sweep_device_get_scan(sweep_device_s device, sweep_error_s* error) 
   out->count = last - first;
 
   for (int32_t it = 0; it < last - first; ++it) {
-    out->angle[it] = sweep_protocol_u16_to_f32(responses[first + it].angle) * 1000.f;
-    out->distance[it] = responses[first + it].distance;
-    out->signal_strength[it] = (responses[first + it].signal_strength / 256.f) * 100.f;
+    // convert the angle from its compact serial format to a float value in degrees
+    // then convert from degrees to milli-degrees, and store it in a signed int32_t
+    out->angle[it] = (int32_t) (sweep_protocol_u16_to_f32(responses[first + it].angle) * 1000.f);
+    // store the distance in a signed int32
+    out->distance[it] = (int32_t) responses[first + it].distance;
+    // store the signal strength in a signed int32
+    out->signal_strength[it] = (int32_t) responses[first + it].signal_strength;
   }
 
   return out;


### PR DESCRIPTION
… and software. 

### Signal Strength Format
The existing implementation stored signal strength as an int in the range 0:100. While this pseudo-normalized format is a conceptual improvement for those unfamiliar with a byte, it is not congruent with the other software and documentation provided by Scanse. To avoid confusion, we should keep it the same. If we wanted to go the normalized route, we might consider normalized float between 0:1. But given the SDK design goals (passing only signed ints) this is better left to the user.

### Clarify storage technique
Additionally, the method by which sensor data is converted and stored in signed ints is somewhat cryptic for the complete novice Sweep user. Given that the SDK may serve as an example of parsing data, this PR adds unnecessary but explicit casts & comments to improve understanding when visually scanning the code. 

### Examples print familiar values
This PR also modifies the examples to print familiar values (ie: degrees, instead of milli-degrees)