### PR TITLE
Implements Communication Error Bit, resolves #20

### DIFF
--- a/libsweep/protocol.h
+++ b/libsweep/protocol.h
@@ -75,14 +75,29 @@ typedef struct {
 static_assert(sizeof(response_param_s) == 9, "response param size mismatch");
 
 typedef struct {
-  uint8_t sync_error;
-  uint16_t angle; // see u16_to_f32
+  uint8_t sync_error; // see response_scan_packet_sync::bits below
+  uint16_t angle;     // see u16_to_f32
   uint16_t distance;
   uint8_t signal_strength;
   uint8_t checksum;
 } SWEEP_PACKED response_scan_packet_s;
 
 static_assert(sizeof(response_scan_packet_s) == 7, "response scan packet size mismatch");
+
+namespace response_scan_packet_sync {
+enum bits : uint8_t {
+  sync = 1 << 0,                // beginning of new full scan
+  communication_error = 1 << 1, // communication error
+
+  // Reserved for future error bits
+  reserved2 = 1 << 2,
+  reserved3 = 1 << 3,
+  reserved4 = 1 << 4,
+  reserved5 = 1 << 5,
+  reserved6 = 1 << 6,
+  reserved7 = 1 << 7,
+};
+}
 
 typedef struct {
   uint8_t cmdByte1;

--- a/libsweep/sweep.cc
+++ b/libsweep/sweep.cc
@@ -188,10 +188,17 @@ sweep_scan_s sweep_device_get_scan(sweep_device_s device, sweep_error_s* error) 
       return nullptr;
     }
 
+    const bool is_sync = responses[received].sync_error & sweep::protocol::response_scan_packet_sync::sync;
+    const bool has_error = (responses[received].sync_error >> 1) != 0; // shift out sync bit, others are errors
+
+    // Discard, try again. At the moment there is only a communication error bit. This may change.
+    if (has_error)
+      continue;
+
     // Only gather a full scan. We could improve this logic to improve on throughput
     // with complicating the code much more (think spsc queue of all responses).
     // On the other hand, we could also discard the sync bit and check repeating angles.
-    if (responses[received].sync_error == 1) {
+    if (is_sync) {
       if (first != 0 && last == SWEEP_MAX_SAMPLES) {
         last = received;
         break;


### PR DESCRIPTION
For #20.

@kent-williams @dcyoung can it happen that the sync bit _and_ the error bit is set? (or really: multiple bits, not specific to those two) Also any insights to error codes for other bits? Or are they unused on the firmware level, too, at the moment?