### PR TITLE
Implements Sample Rate, resolves #21

### DIFF
--- a/libsweep/README.md
+++ b/libsweep/README.md
@@ -168,6 +168,22 @@ The device supports speeds of 1 Hz to 10 Hz.
 In case of error a `sweep_error_s` will be written into `error`.
 
 ```c++
+int32_t sweep_device_get_sample_rate(sweep_device_s device, sweep_error_s* error)
+```
+
+Returns the `sweep_device_s`'s sample rate in Hz.
+In case of error a `sweep_error_s` will be written into `error`.
+
+```c++
+void sweep_device_set_sample_rate(sweep_device_s device, int32_t hz, sweep_error_s* error)
+```
+
+Sets the `sweep_device_s`'s sample rate in Hz.
+The device supports sample rates of 500 Hz, 750 Hz and 1000 Hz.
+The device guarantees for those sample rates but they can be slightly higher by a maximum of roughly 50-100 Hz.
+In case of error a `sweep_error_s` will be written into `error`.
+
+```c++
 void sweep_device_reset(sweep_device_s device, sweep_error_s* error)
 ```
 

--- a/libsweep/dummy.cc
+++ b/libsweep/dummy.cc
@@ -13,6 +13,7 @@ typedef struct sweep_error {
 typedef struct sweep_device {
   bool scanning;
   int32_t motor_speed;
+  int32_t sample_rate;
   int32_t nth_scan_request;
 } sweep_device;
 
@@ -44,7 +45,7 @@ sweep_device_s sweep_device_construct(const char* port, int32_t bitrate, sweep_e
   SWEEP_ASSERT(bitrate > 0);
   SWEEP_ASSERT(error);
 
-  auto out = new sweep_device{/*scanning=*/false, /*motor_speed=*/1, /*nth_scan_request=*/0};
+  auto out = new sweep_device{/*scanning=*/false, /*motor_speed=*/5, /*sample_rate*/ 500, /*nth_scan_request=*/0};
   return out;
 }
 
@@ -124,7 +125,7 @@ int32_t sweep_scan_get_signal_strength(sweep_scan_s scan, int32_t sample) {
   SWEEP_ASSERT(scan);
   SWEEP_ASSERT(sample >= 0 && sample < scan->count && "sample index out of bounds");
 
-  return 100;
+  return 200;
 }
 
 void sweep_scan_destruct(sweep_scan_s scan) {
@@ -146,6 +147,21 @@ void sweep_device_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error
   SWEEP_ASSERT(error);
 
   device->motor_speed = hz;
+}
+
+int32_t sweep_device_get_sample_rate(sweep_device_s device, sweep_error_s* error) {
+  SWEEP_ASSERT(device);
+  SWEEP_ASSERT(error);
+
+  return device->sample_rate;
+}
+
+void sweep_device_set_sample_rate(sweep_device_s device, int32_t hz, sweep_error_s* error) {
+  SWEEP_ASSERT(device);
+  SWEEP_ASSERT(hz == 500 || hz == 750 || hz == 1000);
+  SWEEP_ASSERT(error);
+
+  device->sample_rate = hz;
 }
 
 void sweep_device_reset(sweep_device_s device, sweep_error_s* error) {

--- a/libsweep/examples/example.c
+++ b/libsweep/examples/example.c
@@ -39,6 +39,12 @@ int main() {
 
   fprintf(stdout, "Motor Speed: %" PRId32 " Hz\n", speed);
 
+  // The Sweep's sample rate in Hz
+  int32_t rate = sweep_device_get_sample_rate(sweep, &error);
+  check(error);
+
+  fprintf(stdout, "Sample Rate: %" PRId32 " Hz\n", rate);
+
   // Capture scans
   sweep_device_start_scanning(sweep, &error);
   check(error);

--- a/libsweep/examples/example.cc
+++ b/libsweep/examples/example.cc
@@ -10,6 +10,9 @@ int main() try {
 
   device.start_scanning();
 
+  std::cout << "Motor Speed: " << device.get_motor_speed() << " Hz" << std::endl;
+  std::cout << "Sample Rate: " << device.get_sample_rate() << " Hz" << std::endl;
+
   for (auto n = 0; n < 10; ++n) {
     const sweep::scan scan = device.get_scan();
 

--- a/libsweep/protocol.cc
+++ b/libsweep/protocol.cc
@@ -10,6 +10,8 @@ const uint8_t DATA_ACQUISITION_START[2] = {'D', 'S'};
 const uint8_t DATA_ACQUISITION_STOP[2] = {'D', 'X'};
 const uint8_t MOTOR_SPEED_ADJUST[2] = {'M', 'S'};
 const uint8_t MOTOR_INFORMATION[2] = {'M', 'I'};
+const uint8_t SAMPLE_RATE_ADJUST[2] = {'L', 'R'};
+const uint8_t SAMPLE_RATE_INFORMATION[2] = {'L', 'I'};
 const uint8_t VERSION_INFORMATION[2] = {'I', 'V'};
 const uint8_t DEVICE_INFORMATION[2] = {'I', 'D'};
 const uint8_t RESET_DEVICE[2] = {'R', 'R'};
@@ -114,8 +116,6 @@ void read_response_header(serial::device_s serial, const uint8_t cmd[2], respons
   SWEEP_ASSERT(header);
   SWEEP_ASSERT(error);
 
-  const uint8_t* cmdBytes = (const uint8_t*)cmd;
-
   serial::error_s serialerror = nullptr;
 
   serial::device_read(serial, header, sizeof(response_header_s), &serialerror);
@@ -133,7 +133,7 @@ void read_response_header(serial::device_s serial, const uint8_t cmd[2], respons
     return;
   }
 
-  bool ok = header->cmdByte1 == cmdBytes[0] && header->cmdByte2 == cmdBytes[1];
+  bool ok = header->cmdByte1 == cmd[0] && header->cmdByte2 == cmd[1];
 
   if (!ok) {
     *error = error_construct("invalid header response commands");
@@ -146,8 +146,6 @@ void read_response_param(serial::device_s serial, const uint8_t cmd[2], response
   SWEEP_ASSERT(cmd);
   SWEEP_ASSERT(param);
   SWEEP_ASSERT(error);
-
-  const uint8_t* cmdBytes = (const uint8_t*)cmd;
 
   serial::error_s serialerror = nullptr;
 
@@ -166,7 +164,7 @@ void read_response_param(serial::device_s serial, const uint8_t cmd[2], response
     return;
   }
 
-  bool ok = param->cmdByte1 == cmdBytes[0] && param->cmdByte2 == cmdBytes[1];
+  bool ok = param->cmdByte1 == cmd[0] && param->cmdByte2 == cmd[1];
 
   if (!ok) {
     *error = error_construct("invalid param response commands");
@@ -203,8 +201,6 @@ void read_response_info_motor(serial::device_s serial, const uint8_t cmd[2], res
   SWEEP_ASSERT(info);
   SWEEP_ASSERT(error);
 
-  const uint8_t* cmdBytes = (const uint8_t*)cmd;
-
   serial::error_s serialerror = nullptr;
 
   serial::device_read(serial, info, sizeof(response_info_motor_s), &serialerror);
@@ -215,10 +211,35 @@ void read_response_info_motor(serial::device_s serial, const uint8_t cmd[2], res
     return;
   }
 
-  bool ok = info->cmdByte1 == cmdBytes[0] && info->cmdByte2 == cmdBytes[1];
+  bool ok = info->cmdByte1 == cmd[0] && info->cmdByte2 == cmd[1];
 
   if (!ok) {
     *error = error_construct("invalid motor info response commands");
+    return;
+  }
+}
+
+void read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_sample_rate_s* info,
+                                    error_s* error) {
+  SWEEP_ASSERT(serial);
+  SWEEP_ASSERT(cmd);
+  SWEEP_ASSERT(info);
+  SWEEP_ASSERT(error);
+
+  serial::error_s serialerror = nullptr;
+
+  serial::device_read(serial, info, sizeof(response_info_sample_rate_s), &serialerror);
+
+  if (serialerror) {
+    *error = error_construct("unable to read response sample rate info");
+    serial::error_destruct(serialerror);
+    return;
+  }
+
+  bool ok = info->cmdByte1 == cmd[0] && info->cmdByte2 == cmd[1];
+
+  if (!ok) {
+    *error = error_construct("invalid sample rate info response commands");
     return;
   }
 }

--- a/libsweep/sweep.h
+++ b/libsweep/sweep.h
@@ -54,6 +54,9 @@ SWEEP_API int32_t sweep_scan_get_signal_strength(sweep_scan_s scan, int32_t samp
 SWEEP_API int32_t sweep_device_get_motor_speed(sweep_device_s device, sweep_error_s* error);
 SWEEP_API void sweep_device_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error_s* error);
 
+SWEEP_API int32_t sweep_device_get_sample_rate(sweep_device_s device, sweep_error_s* error);
+SWEEP_API void sweep_device_set_sample_rate(sweep_device_s device, int32_t hz, sweep_error_s* error);
+
 SWEEP_API void sweep_device_reset(sweep_device_s device, sweep_error_s* error);
 
 #ifdef __cplusplus

--- a/libsweep/sweep.hpp
+++ b/libsweep/sweep.hpp
@@ -51,6 +51,9 @@ public:
   std::int32_t get_motor_speed();
   void set_motor_speed(std::int32_t speed);
 
+  std::int32_t get_sample_rate();
+  void set_sample_rate(std::int32_t speed);
+
   scan get_scan();
 
   void reset();
@@ -90,6 +93,12 @@ std::int32_t sweep::get_motor_speed() { return ::sweep_device_get_motor_speed(de
 
 void sweep::set_motor_speed(std::int32_t speed) {
   ::sweep_device_set_motor_speed(device.get(), speed, detail::error_to_exception{});
+}
+
+std::int32_t sweep::get_sample_rate() { return ::sweep_device_get_sample_rate(device.get(), detail::error_to_exception{}); }
+
+void sweep::set_sample_rate(std::int32_t rate) {
+  ::sweep_device_set_sample_rate(device.get(), rate, detail::error_to_exception{});
 }
 
 scan sweep::get_scan() {

--- a/sweepjs/README.md
+++ b/sweepjs/README.md
@@ -22,6 +22,9 @@ sweep.stopScanning();
 speed = sweep.getMotorSpeed();
 sweep.setMotorSpeed(Number);
 
+rate = sweep.getSampleRate();
+sweep.setSampleRate(Number);
+
 sweep.scan(function (err, samples) {
   handle(err);
 

--- a/sweepjs/index.js
+++ b/sweepjs/index.js
@@ -12,6 +12,12 @@ if (require.main === module) {
 
   sweep.startScanning();
 
+  var speed = sweep.getMotorSpeed();
+  var rate = sweep.getSampleRate();
+
+  console.log(util.format('Motor speed: %d Hz', speed));
+  console.log(util.format('Sample rate: %d Hz', rate));
+
   sweep.scan(function (err, samples) {
     if (err) {
       return console.log(err);

--- a/sweepjs/sweepjs.cc
+++ b/sweepjs/sweepjs.cc
@@ -64,6 +64,8 @@ NAN_MODULE_INIT(Sweep::Init) {
   SetPrototypeMethod(fnTp, "scan", scan);
   SetPrototypeMethod(fnTp, "getMotorSpeed", getMotorSpeed);
   SetPrototypeMethod(fnTp, "setMotorSpeed", setMotorSpeed);
+  SetPrototypeMethod(fnTp, "getSampleRate", getSampleRate);
+  SetPrototypeMethod(fnTp, "setSampleRate", setSampleRate);
   SetPrototypeMethod(fnTp, "reset", reset);
 
   const auto fn = Nan::GetFunction(fnTp).ToLocalChecked();
@@ -220,6 +222,30 @@ NAN_METHOD(Sweep::setMotorSpeed) {
   const auto speed = Nan::To<int32_t>(info[0]).FromJust();
 
   ::sweep_device_set_motor_speed(self->device.get(), speed, ErrorToNanException{});
+}
+
+NAN_METHOD(Sweep::getSampleRate) {
+  auto* const self = Nan::ObjectWrap::Unwrap<Sweep>(info.Holder());
+
+  if (info.Length() != 0) {
+    return Nan::ThrowTypeError("No arguments expected");
+  }
+
+  const auto rate = ::sweep_device_get_sample_rate(self->device.get(), ErrorToNanException{});
+
+  info.GetReturnValue().Set(Nan::New(rate));
+}
+
+NAN_METHOD(Sweep::setSampleRate) {
+  auto* const self = Nan::ObjectWrap::Unwrap<Sweep>(info.Holder());
+
+  if (info.Length() != 1 && !info[0]->IsNumber()) {
+    return Nan::ThrowTypeError("Sample rate in Hz as number expected");
+  }
+
+  const auto rate = Nan::To<int32_t>(info[0]).FromJust();
+
+  ::sweep_device_set_sample_rate(self->device.get(), rate, ErrorToNanException{});
 }
 
 NAN_METHOD(Sweep::reset) {

--- a/sweepjs/sweepjs.h
+++ b/sweepjs/sweepjs.h
@@ -22,6 +22,9 @@ private:
   static NAN_METHOD(getMotorSpeed);
   static NAN_METHOD(setMotorSpeed);
 
+  static NAN_METHOD(getSampleRate);
+  static NAN_METHOD(setSampleRate);
+
   static NAN_METHOD(reset);
 
   static Nan::Persistent<v8::Function>& constructor();

--- a/sweeppy/README.md
+++ b/sweeppy/README.md
@@ -20,13 +20,16 @@ See [sweeppy.py](sweeppy.py) for interface and example.
 
 ### Interface
 
-```python
+```
 class Sweep:
     def start_scanning(self) -> None
     def stop_scanning(self) -> None
 
     def get_motor_speed(self) -> int
     def set_motor_speed(self, speed) -> None
+
+    def get_sample_rate(self) -> int
+    def set_sample_rate(self, speed) -> None
 
     def get_scans(self) -> Iterable[Scan]
 

--- a/sweeppy/sweeppy.py
+++ b/sweeppy/sweeppy.py
@@ -54,6 +54,12 @@ libsweep.sweep_device_get_motor_speed.argtypes = [ctypes.c_void_p, ctypes.c_void
 libsweep.sweep_device_set_motor_speed.restype = None
 libsweep.sweep_device_set_motor_speed.argtypes = [ctypes.c_void_p, ctypes.c_int32, ctypes.c_void_p]
 
+libsweep.sweep_device_get_sample_rate.restype = ctypes.c_int32
+libsweep.sweep_device_get_sample_rate.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+libsweep.sweep_device_set_sample_rate.restype = None
+libsweep.sweep_device_set_sample_rate.argtypes = [ctypes.c_void_p, ctypes.c_int32, ctypes.c_void_p]
+
 libsweep.sweep_device_reset.restype = None
 libsweep.sweep_device_reset.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
@@ -153,6 +159,26 @@ class Sweep:
         if error:
             raise _error_to_exception(error)
 
+    def get_sample_rate(_):
+        _._assert_scoped()
+
+        error = ctypes.c_void_p()
+        speed = libsweep.sweep_device_get_sample_rate(_.device, ctypes.byref(error))
+
+        if error:
+            raise _error_to_exception(error)
+
+        return speed
+
+    def set_sample_rate(_, speed):
+        _._assert_scoped()
+
+        error = ctypes.c_void_p()
+        libsweep.sweep_device_set_sample_rate(_.device, speed, ctypes.byref(error))
+
+        if error:
+            raise _error_to_exception(error)
+
     def get_scans(_):
         _._assert_scoped()
 
@@ -191,7 +217,10 @@ if __name__ == '__main__':
         sweep.start_scanning()
 
         speed = sweep.get_motor_speed()
-        sweep.set_motor_speed(speed + 1)
+        rate = sweep.get_sample_rate()
+
+        print('Motor Speed: {} Hz'.format(speed))
+        print('Sample Rate: {} Hz'.format(rate))
 
         # get_scans is coroutine-based generator lazily returning scans ad infinitum
         for n, scan in enumerate(sweep.get_scans()):


### PR DESCRIPTION
500 Hz:

![500hz](https://cloud.githubusercontent.com/assets/527241/22855356/9e6eb7e2-f07f-11e6-81e3-64e7ad779394.png)

750 Hz:

![750hz](https://cloud.githubusercontent.com/assets/527241/22855357/9e714a8e-f07f-11e6-8a86-b1bb205904f8.png)

Looks like the signal strength goes down quite a bit from my first experiences. No real difference between 750 Hz and 1000 Hz. Resolution goes up (even though not _that_ much (?)), looks good over all!

@dcyoung @kent-williams can you take a quick look. Especially since you know more about firmware plans. I opted for the user having to explicitly specify the Hz, and let the README document the support for 500 Hz, 750 Hz and 1000 Hz.

From your docs it looks like the device can be off by ~50-100 Hz. Which means high-precision applications probably require accurate timestamps (?) (see https://github.com/scanse/sweep-sdk/issues/19).

References:
- https://github.com/scanse/sweep-sdk/commit/449565f45fea61a7b99adc942d4f6c4ecb7005b4
- https://github.com/scanse/sweep-sdk/commit/83043a66d2ca221c7c55b902e5be5781e839dd73