### PR TITLE
Pr/exceptions

### DIFF
--- a/libsweep/CMakeLists.txt
+++ b/libsweep/CMakeLists.txt
@@ -1,0 +1,19 @@
+project(sweep)
+
+cmake_minimum_required(VERSION 3.5)
+
+SET(COMMON_SRC_FILES sweep.cc protocol.cc sweep.h sweep.hpp serial.h protocol.h)
+
+if (MSVC)
+    SET ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX" )
+    SET (PALTFORM_SRC_FILES serial_win.cc)
+else ()
+    SET ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror" )
+	SET (PALTFORM_SRC_FILESserial_unix.cc)
+endif()
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
+
+
+add_library(${PROJECT_NAME} SHARED ${COMMON_SRC_FILES} ${PALTFORM_SRC_FILES})
+

--- a/libsweep/Error.h
+++ b/libsweep/Error.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <stdexcept>
+
+namespace sweep {
+struct ErrorBase : std::exception {
+  // parameter MUST be a STRING LITTERAL
+  template <size_t N> ErrorBase(const char (&msg)[N]) : _msg{&msg[0]} {}
+  const char* what() const noexcept override { return _msg; };
+
+private:
+  const char* _msg;
+};
+}

--- a/libsweep/config.mk
+++ b/libsweep/config.mk
@@ -5,7 +5,7 @@ UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
   PREFIX ?= /usr
-  CXXFLAGS += -O2 -Wall -Wextra -pedantic -std=c++11 -fvisibility=hidden -fPIC -fno-rtti -fno-exceptions -pthread
+  CXXFLAGS += -O2 -Wall -Wextra -pedantic -std=c++11 -fvisibility=hidden -fPIC -fno-rtti -pthread
   LDFLAGS += -shared -Wl,-soname,libsweep.so.$(VERSION_MAJOR)
   LDLIBS += -lstdc++ -lpthread
 else ifeq ($(UNAME), Darwin)

--- a/libsweep/protocol.cc
+++ b/libsweep/protocol.cc
@@ -14,81 +14,39 @@ const uint8_t VERSION_INFORMATION[2] = {'I', 'V'};
 const uint8_t DEVICE_INFORMATION[2] = {'I', 'D'};
 const uint8_t RESET_DEVICE[2] = {'R', 'R'};
 
-typedef struct error {
-  const char* what; // always literal, do not deallocate
-} error;
-
-// Constructor hidden from users
-static error_s error_construct(const char* what) {
-  SWEEP_ASSERT(what);
-
-  auto out = new error{what};
-  return out;
+static uint8_t checksum_response_header(const response_header_s& v) {
+  return ((v.cmdStatusByte1 + v.cmdStatusByte2) & 0x3F) + 0x30;
 }
 
-const char* error_message(error_s error) {
-  SWEEP_ASSERT(error);
-
-  return error->what;
+static uint8_t checksum_response_param(const response_param_s& v) {
+  return ((v.cmdStatusByte1 + v.cmdStatusByte2) & 0x3F) + 0x30;
 }
 
-void error_destruct(error_s error) {
-  SWEEP_ASSERT(error);
-
-  delete error;
-}
-
-static uint8_t checksum_response_header(response_header_s* v) {
-  SWEEP_ASSERT(v);
-
-  return ((v->cmdStatusByte1 + v->cmdStatusByte2) & 0x3F) + 0x30;
-}
-
-static uint8_t checksum_response_param(response_param_s* v) {
-  SWEEP_ASSERT(v);
-
-  return ((v->cmdStatusByte1 + v->cmdStatusByte2) & 0x3F) + 0x30;
-}
-
-static uint8_t checksum_response_scan_packet(response_scan_packet_s* v) {
-  SWEEP_ASSERT(v);
-
+static uint8_t checksum_response_scan_packet(const response_scan_packet_s& v) {
   uint64_t checksum = 0;
-  checksum += v->sync_error;
-  checksum += v->angle & 0xff00;
-  checksum += v->angle & 0x00ff;
-  checksum += v->distance & 0xff00;
-  checksum += v->distance & 0x00ff;
-  checksum += v->signal_strength;
+  checksum += v.sync_error;
+  checksum += v.angle & 0xff00;
+  checksum += v.angle & 0x00ff;
+  checksum += v.distance & 0xff00;
+  checksum += v.distance & 0x00ff;
+  checksum += v.signal_strength;
   return checksum % 255;
 }
 
-void write_command(serial::device_s serial, const uint8_t cmd[2], error_s* error) {
-  SWEEP_ASSERT(serial);
+void write_command(serial::Device& serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(error);
 
   cmd_packet_s packet;
   packet.cmdByte1 = cmd[0];
   packet.cmdByte2 = cmd[1];
   packet.cmdParamTerm = '\n';
 
-  serial::error_s serialerror = nullptr;
-
-  serial::device_write(serial, &packet, sizeof(cmd_packet_s), &serialerror);
-
-  if (serialerror) {
-    *error = error_construct("unable to write command");
-    serial::error_destruct(serialerror);
-    return;
-  }
+  serial.write(&packet, sizeof(cmd_packet_s));
 }
 
-void write_command_with_arguments(serial::device_s serial, const uint8_t cmd[2], const uint8_t arg[2], error_s* error) {
-  SWEEP_ASSERT(serial);
+void write_command_with_arguments(serial::Device& serial, const uint8_t cmd[2], const uint8_t arg[2]) {
   SWEEP_ASSERT(cmd);
   SWEEP_ASSERT(arg);
-  SWEEP_ASSERT(error);
 
   cmd_param_packet_s packet;
   packet.cmdByte1 = cmd[0];
@@ -97,130 +55,61 @@ void write_command_with_arguments(serial::device_s serial, const uint8_t cmd[2],
   packet.cmdParamByte2 = arg[1];
   packet.cmdParamTerm = '\n';
 
-  serial::error_s serialerror = nullptr;
-
-  serial::device_write(serial, &packet, sizeof(cmd_param_packet_s), &serialerror);
-
-  if (serialerror) {
-    *error = error_construct("unable to write command with arguments");
-    serial::error_destruct(serialerror);
-    return;
-  }
+  serial.write(&packet, sizeof(cmd_param_packet_s));
 }
 
-void read_response_header(serial::device_s serial, const uint8_t cmd[2], response_header_s* header, error_s* error) {
-  SWEEP_ASSERT(serial);
+response_header_s read_response_header(serial::Device& serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(header);
-  SWEEP_ASSERT(error);
 
-  const uint8_t* cmdBytes = (const uint8_t*)cmd;
+  response_header_s header;
+  serial.read(&header, sizeof(header));
 
-  serial::error_s serialerror = nullptr;
-
-  serial::device_read(serial, header, sizeof(response_header_s), &serialerror);
-
-  if (serialerror) {
-    *error = error_construct("unable to read response header");
-    serial::error_destruct(serialerror);
-    return;
+  if (header.cmdSum != checksum_response_header(header)) {
+    throw Error{"invalid response header checksum"};
   }
 
-  uint8_t checksum = checksum_response_header(header);
-
-  if (checksum != header->cmdSum) {
-    *error = error_construct("invalid response header checksum");
-    return;
+  if (header.cmdByte1 != cmd[0] || header.cmdByte2 != cmd[1]) {
+    throw Error{"invalid header response commands"};
   }
-
-  bool ok = header->cmdByte1 == cmdBytes[0] && header->cmdByte2 == cmdBytes[1];
-
-  if (!ok) {
-    *error = error_construct("invalid header response commands");
-    return;
-  }
+  return header;
 }
 
-void read_response_param(serial::device_s serial, const uint8_t cmd[2], response_param_s* param, error_s* error) {
-  SWEEP_ASSERT(serial);
+response_param_s read_response_param(serial::Device& serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(param);
-  SWEEP_ASSERT(error);
 
-  const uint8_t* cmdBytes = (const uint8_t*)cmd;
+  response_param_s param;
+  serial.read(&param, sizeof(param));
 
-  serial::error_s serialerror = nullptr;
-
-  serial::device_read(serial, param, sizeof(response_param_s), &serialerror);
-
-  if (serialerror) {
-    *error = error_construct("unable to read response param header");
-    serial::error_destruct(serialerror);
-    return;
+  if (param.cmdSum != checksum_response_param(param)) {
+    throw Error{"invalid response param header checksum"};
   }
 
-  uint8_t checksum = checksum_response_param(param);
-
-  if (checksum != param->cmdSum) {
-    *error = error_construct("invalid response param header checksum");
-    return;
+  if (param.cmdByte1 != cmd[0] || param.cmdByte2 != cmd[1]) {
+    throw Error{"invalid param response commands"};
   }
-
-  bool ok = param->cmdByte1 == cmdBytes[0] && param->cmdByte2 == cmdBytes[1];
-
-  if (!ok) {
-    *error = error_construct("invalid param response commands");
-    return;
-  }
+  return param;
 }
 
-void read_response_scan(serial::device_s serial, response_scan_packet_s* scan, error_s* error) {
-  SWEEP_ASSERT(serial);
+void read_response_scan(serial::Device& serial, response_scan_packet_s* scan) {
   SWEEP_ASSERT(scan);
-  SWEEP_ASSERT(error);
 
-  serial::error_s serialerror = nullptr;
+  serial.read(scan, sizeof(*scan));
 
-  serial::device_read(serial, scan, sizeof(response_scan_packet_s), &serialerror);
-
-  if (serialerror) {
-    *error = error_construct("invalid response scan packet checksum");
-    serial::error_destruct(serialerror);
-    return;
-  }
-
-  uint8_t checksum = checksum_response_scan_packet(scan);
-
-  if (checksum != scan->checksum) {
-    *error = error_construct("invalid scan response commands");
-    return;
+  if (scan->checksum != checksum_response_scan_packet(*scan)) {
+    throw Error{"invalid scan response commands"};
   }
 }
 
-void read_response_info_motor(serial::device_s serial, const uint8_t cmd[2], response_info_motor_s* info, error_s* error) {
-  SWEEP_ASSERT(serial);
+response_info_motor_s read_response_info_motor(serial::Device& serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(info);
-  SWEEP_ASSERT(error);
+  response_info_motor_s info;
 
-  const uint8_t* cmdBytes = (const uint8_t*)cmd;
+  serial.read(&info, sizeof(info));
 
-  serial::error_s serialerror = nullptr;
-
-  serial::device_read(serial, info, sizeof(response_info_motor_s), &serialerror);
-
-  if (serialerror) {
-    *error = error_construct("unable to read response motor info");
-    serial::error_destruct(serialerror);
-    return;
+  if (info.cmdByte1 != cmd[0] || info.cmdByte2 != cmd[1]) {
+    throw Error{"invalid motor info response commands"};
   }
-
-  bool ok = info->cmdByte1 == cmdBytes[0] && info->cmdByte2 == cmdBytes[1];
-
-  if (!ok) {
-    *error = error_construct("invalid motor info response commands");
-    return;
-  }
+  return info;
 }
 
 } // ns protocol

--- a/libsweep/protocol.h
+++ b/libsweep/protocol.h
@@ -8,16 +8,16 @@
 
 #include <stdint.h>
 
+#include "Error.h"
 #include "serial.h"
 #include "sweep.h"
 
 namespace sweep {
 namespace protocol {
 
-typedef struct error* error_s;
-
-const char* error_message(error_s error);
-void error_destruct(error_s error);
+struct Error : ErrorBase {
+  using ErrorBase::ErrorBase;
+};
 
 // Command Symbols
 
@@ -31,36 +31,38 @@ extern const uint8_t RESET_DEVICE[2];
 
 // Packets for communication
 
-typedef struct {
+#pragma pack(push, 1)
+
+struct cmd_packet_s {
   uint8_t cmdByte1;
   uint8_t cmdByte2;
   uint8_t cmdParamTerm;
-} SWEEP_PACKED cmd_packet_s;
+};
 
 static_assert(sizeof(cmd_packet_s) == 3, "cmd packet size mismatch");
 
-typedef struct {
+struct cmd_param_packet_s {
   uint8_t cmdByte1;
   uint8_t cmdByte2;
   uint8_t cmdParamByte1;
   uint8_t cmdParamByte2;
   uint8_t cmdParamTerm;
-} SWEEP_PACKED cmd_param_packet_s;
+};
 
 static_assert(sizeof(cmd_param_packet_s) == 5, "cmd param packet size mismatch");
 
-typedef struct {
+struct response_header_s {
   uint8_t cmdByte1;
   uint8_t cmdByte2;
   uint8_t cmdStatusByte1;
   uint8_t cmdStatusByte2;
   uint8_t cmdSum;
   uint8_t term1;
-} SWEEP_PACKED response_header_s;
+};
 
 static_assert(sizeof(response_header_s) == 6, "response header size mismatch");
 
-typedef struct {
+struct response_param_s {
   uint8_t cmdByte1;
   uint8_t cmdByte2;
   uint8_t cmdParamByte1;
@@ -70,21 +72,21 @@ typedef struct {
   uint8_t cmdStatusByte2;
   uint8_t cmdSum;
   uint8_t term2;
-} SWEEP_PACKED response_param_s;
+};
 
 static_assert(sizeof(response_param_s) == 9, "response param size mismatch");
 
-typedef struct {
+struct response_scan_packet_s {
   uint8_t sync_error;
   uint16_t angle; // see u16_to_f32
   uint16_t distance;
   uint8_t signal_strength;
   uint8_t checksum;
-} SWEEP_PACKED response_scan_packet_s;
+};
 
 static_assert(sizeof(response_scan_packet_s) == 7, "response scan packet size mismatch");
 
-typedef struct {
+struct response_info_device_s {
   uint8_t cmdByte1;
   uint8_t cmdByte2;
   uint8_t bit_rate[6];
@@ -94,11 +96,11 @@ typedef struct {
   uint8_t motor_speed[2];
   uint8_t sample_rate[4];
   uint8_t term;
-} SWEEP_PACKED response_info_device_s;
+};
 
 static_assert(sizeof(response_info_device_s) == 18, "response info device size mismatch");
 
-typedef struct {
+struct response_info_version_s {
   uint8_t cmdByte1;
   uint8_t cmdByte2;
   uint8_t model[5];
@@ -109,32 +111,34 @@ typedef struct {
   uint8_t hardware_version;
   uint8_t serial_no[8];
   uint8_t term;
-} SWEEP_PACKED response_info_version_s;
+};
 
 static_assert(sizeof(response_info_version_s) == 21, "response info version size mismatch");
 
-typedef struct {
+struct response_info_motor_s {
   uint8_t cmdByte1;
   uint8_t cmdByte2;
   uint8_t motor_speed[2];
   uint8_t term;
-} SWEEP_PACKED response_info_motor_s;
+};
 
 static_assert(sizeof(response_info_motor_s) == 5, "response info motor size mismatch");
 
+#pragma pack(pop)
+
 // Read and write specific packets
 
-void write_command(sweep::serial::device_s serial, const uint8_t cmd[2], error_s* error);
+void write_command(sweep::serial::Device& serial, const uint8_t cmd[2]);
 
-void write_command_with_arguments(sweep::serial::device_s serial, const uint8_t cmd[2], const uint8_t arg[2], error_s* error);
+void write_command_with_arguments(sweep::serial::Device& serial, const uint8_t cmd[2], const uint8_t arg[2]);
 
-void read_response_header(sweep::serial::device_s serial, const uint8_t cmd[2], response_header_s* header, error_s* error);
+response_header_s read_response_header(sweep::serial::Device& serial, const uint8_t cmd[2]);
 
-void read_response_param(sweep::serial::device_s serial, const uint8_t cmd[2], response_param_s* param, error_s* error);
+response_param_s read_response_param(sweep::serial::Device& serial, const uint8_t cmd[2]);
 
-void read_response_scan(sweep::serial::device_s serial, response_scan_packet_s* scan, error_s* error);
+void read_response_scan(sweep::serial::Device& serial, response_scan_packet_s* scan);
 
-void read_response_info_motor(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_motor_s* info, error_s* error);
+response_info_motor_s read_response_info_motor(sweep::serial::Device& serial, const uint8_t cmd[2]);
 
 // Some protocol conversion utilities
 inline float u16_to_f32(uint16_t v) { return ((float)(v >> 4u)) + (v & 15u) / 16.0f; }
@@ -147,8 +151,8 @@ inline void speed_to_ascii_bytes(int32_t speed, uint8_t bytes[2]) {
   // Speed values are still ASCII codes, numbers begin at code point 48
   const uint8_t ASCIINumberBlockOffset = 48;
 
-  uint8_t num1 = (speed / 10) + ASCIINumberBlockOffset;
-  uint8_t num2 = (speed % 10) + ASCIINumberBlockOffset;
+  uint8_t num1 = (uint8_t)(speed / 10) + ASCIINumberBlockOffset;
+  uint8_t num2 = (uint8_t)(speed % 10) + ASCIINumberBlockOffset;
 
   bytes[0] = num1;
   bytes[1] = num2;

--- a/libsweep/serial.h
+++ b/libsweep/serial.h
@@ -7,24 +7,29 @@
  */
 
 #include "sweep.h"
+#include "Error.h"
 
-#include <stdint.h>
+#include <memory>
 
 namespace sweep {
 namespace serial {
 
-typedef struct device* device_s;
-typedef struct error* error_s;
+struct Error : public ErrorBase {
+	using ErrorBase::ErrorBase;
+};
 
-const char* error_message(error_s error);
-void error_destruct(error_s error);
+class Device {
+public:
+	Device(const char* port, int32_t bitrate);
+	Device(Device&& other) = default;
+	~Device();
 
-device_s device_construct(const char* port, int32_t bitrate, error_s* error);
-void device_destruct(device_s serial);
-
-void device_read(device_s serial, void* to, int32_t len, error_s* error);
-void device_write(device_s serial, const void* from, int32_t len, error_s* error);
-void device_flush(device_s serial, error_s* error);
+	void read(void* to, int32_t len);
+	void write(const void* from, int32_t len);
+	void flush();
+private:
+	std::unique_ptr<struct State> _state;
+};
 
 } // ns serial
 } // ns sweep

--- a/libsweep/serial_win.cc
+++ b/libsweep/serial_win.cc
@@ -1,9 +1,9 @@
 #include "serial.h"
 
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cstdio>
 #include <string>
 
 #include <windows.h>
@@ -11,77 +11,40 @@
 namespace sweep {
 namespace serial {
 
-typedef struct error {
-  const char* what; // always literal, do not free
-} error;
-
-typedef struct device {
+struct State {
   HANDLE fd;
   OVERLAPPED ro_;
   OVERLAPPED wo_;
-} device;
+};
 
-// Constructor hidden from users
-static error_s error_construct(const char* what) {
-  SWEEP_ASSERT(what);
-
-  auto out = new error{what};
-  return out;
-}
-
-const char* error_message(error_s error) {
-  SWEEP_ASSERT(error);
-
-  return error->what;
-}
-
-void error_destruct(error_s error) {
-  SWEEP_ASSERT(error);
-
-  delete error;
-}
-
-static int32_t detail_get_port_number(const char* port, error_s* error) {
+static int32_t detail_get_port_number(const char* port) {
   SWEEP_ASSERT(port);
-  SWEEP_ASSERT(error);
 
   if (strlen(port) <= 3) {
-    *error = error_construct("invalid port name");
-    return -1;
+    throw Error{"invalid port name"};
   }
 
-  char* end;
-  long parsed_int = std::strtoll(port + 3, &end, 10);
+  long parsed_int = std::strtol(port + 3, nullptr, 10);
 
   if (parsed_int >= 0 && parsed_int <= 255)
     return parsed_int;
 
-  *error = error_construct("invalid port name");
-  return -1;
+  throw Error{"invalid port name"};
 }
 
-device_s device_construct(const char* port, int32_t bitrate, error_s* error) {
+Device::Device(const char* port, int32_t bitrate) {
   SWEEP_ASSERT(port);
   SWEEP_ASSERT(bitrate > 0);
-  SWEEP_ASSERT(error);
 
   if (bitrate != 115200) {
-    *error = error_construct("baud rate is not supported");
-    return nullptr;
+    throw Error{"baud rate is not supported"};
   }
 
   // read port number from the port name
-  error_s port_num_error = nullptr;
-  int port_num = detail_get_port_number(port, &port_num_error);
-
-  if (port_num_error) {
-    *error = port_num_error;
-    return nullptr;
-  }
+  int port_num = detail_get_port_number(port);
 
   // Construct formal serial port name
-  std::string port_name{"\\\\.\\COM"};
-  port_name += std::to_string(port_num);
+  std::string port_name = "\\\\.\\COM" + std::to_string(port_num);
 
   // try to open the port
   auto hComm = CreateFile(port_name.c_str(),            // port name
@@ -93,17 +56,15 @@ device_s device_construct(const char* port, int32_t bitrate, error_s* error) {
                           NULL);                        // Null for serial ports
 
   if (hComm == INVALID_HANDLE_VALUE) {
-    *error = error_construct("opening serial port failed");
-    return nullptr;
+    throw Error{"opening serial port failed"};
   }
 
   // retrieve the current comm state
   DCB dcb_serial_params;
   dcb_serial_params.DCBlength = sizeof(dcb_serial_params);
   if (!GetCommState(hComm, &dcb_serial_params)) {
-    *error = error_construct("retrieving current serial port state failed");
     CloseHandle(hComm);
-    return nullptr;
+    throw Error{"retrieving current serial port state failed"};
   }
 
   // set the parameters to match the uART settings from the Sweep Comm Protocol
@@ -115,17 +76,15 @@ device_s device_construct(const char* port, int32_t bitrate, error_s* error) {
 
   // set the serial port parameters to the specified values
   if (!SetCommState(hComm, &dcb_serial_params)) {
-    *error = error_construct("setting serial port parameters failed");
     CloseHandle(hComm);
-    return nullptr;
+    throw Error{"setting serial port parameters failed"};
   }
 
   // specify timeouts (all values in milliseconds)
   COMMTIMEOUTS timeouts;
   if (!GetCommTimeouts(hComm, &timeouts)) {
-    *error = error_construct("retrieving current serial port timeouts failed");
     CloseHandle(hComm);
-    return nullptr;
+    throw Error{"retrieving current serial port timeouts failed"};
   }
   timeouts.ReadIntervalTimeout = 50;         // max time between arrival of two bytes before ReadFile() returns
   timeouts.ReadTotalTimeoutConstant = 50;    // used to calculate total time-out period for read operations
@@ -135,9 +94,8 @@ device_s device_construct(const char* port, int32_t bitrate, error_s* error) {
 
   // set the timeouts
   if (!SetCommTimeouts(hComm, &timeouts)) {
-    *error = error_construct("setting serial port timeouts failed");
     CloseHandle(hComm);
-    return nullptr;
+    throw Error{"setting serial port timeouts failed"};
   }
 
   // create the overlapped os reader
@@ -147,67 +105,55 @@ device_s device_construct(const char* port, int32_t bitrate, error_s* error) {
   // Create the overlapped read event. Must be closed before exiting
   os_reader.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
   if (os_reader.hEvent == NULL) {
-    *error = error_construct("creating overlapped read event failed");
     CloseHandle(hComm);
-    return nullptr;
+    throw Error{"creating overlapped read event failed"};
   }
   // Create the overlapped write event. Must be closed before exiting
   os_write.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
   if (os_write.hEvent == NULL) {
-    *error = error_construct("creating overlapped write event failed");
     CloseHandle(hComm);
-    return nullptr;
+    throw Error{"creating overlapped write event failed"};
   }
 
   // set the comm mask
   if (!SetCommMask(hComm, EV_RXCHAR | EV_ERR)) {
-    *error = error_construct("setting comm mask failed");
     CloseHandle(hComm);
     CloseHandle(os_reader.hEvent);
     CloseHandle(os_write.hEvent);
-    return nullptr;
+    throw Error{"setting comm mask failed"};
   }
 
   // purge the comm port of any pre-existing data or errors
   if (!PurgeComm(hComm, PURGE_RXABORT | PURGE_TXABORT | PURGE_RXCLEAR | PURGE_TXCLEAR)) {
-    *error = error_construct("flushing serial port failed during serial device construction");
     CloseHandle(hComm);
     CloseHandle(os_reader.hEvent);
     CloseHandle(os_write.hEvent);
-    return nullptr;
+    throw Error{"flushing serial port failed during serial device construction"};
   }
 
   // create the serial device
-  auto out = new device{hComm, os_reader, os_write};
-
-  return out;
+  _state = std::unique_ptr<State>(new State{hComm, os_reader, os_write});
 }
 
-void device_destruct(device_s serial) {
-  SWEEP_ASSERT(serial);
-
-  error_s ignore = nullptr;
-  device_flush(serial, &ignore);
+Device::~Device() {
+  try {
+    flush();
+  } catch (...) {
+  }
 
   // close the serial port
-  CloseHandle(serial->fd);
+  CloseHandle(_state->fd);
 
   // close the overlapped read event
-  CloseHandle(serial->ro_.hEvent);
+  CloseHandle(_state->ro_.hEvent);
 
   // close the overlapped write event
-  CloseHandle(serial->wo_.hEvent);
-
-  (void)ignore; // nothing we can do here
-
-  delete serial;
+  CloseHandle(_state->wo_.hEvent);
 }
 
-void device_read(device_s serial, void* to, int32_t len, error_s* error) {
-  SWEEP_ASSERT(serial);
+void Device::read(void* to, int32_t len) {
   SWEEP_ASSERT(to);
   SWEEP_ASSERT(len >= 0);
-  SWEEP_ASSERT(error);
 
   DWORD rx_read = 0;
   DWORD total_num_bytes_read = 0;
@@ -215,75 +161,66 @@ void device_read(device_s serial, void* to, int32_t len, error_s* error) {
   // read bytes until "len" bytes have been read
   while (total_num_bytes_read < (DWORD)len) {
 
-    if (!ReadFile(serial->fd, (unsigned char*)to + total_num_bytes_read, len - total_num_bytes_read, &rx_read, &(serial->ro_))) {
-      *error = error_construct("reading from serial device failed");
-      return;
+    if (!ReadFile(_state->fd, (unsigned char*)to + total_num_bytes_read, len - total_num_bytes_read, &rx_read, &(_state->ro_))) {
+      throw Error{"reading from serial device failed"};
     }
     total_num_bytes_read += rx_read;
   }
 
   SWEEP_ASSERT(total_num_bytes_read == (DWORD)len && "reliable read failed to read requested number of bytes");
   if (total_num_bytes_read != (DWORD)len)
-    *error = error_construct("reading from serial device failed");
+    throw Error{"reading from serial device failed"};
 }
 
-void device_write(device_s serial, const void* from, int32_t len, error_s* error) {
-  SWEEP_ASSERT(serial);
+void Device::write(const void* from, int32_t len) {
   SWEEP_ASSERT(from);
   SWEEP_ASSERT(len >= 0);
-  SWEEP_ASSERT(error);
 
   DWORD err = 0;
   DWORD tx_written = 0;
   DWORD total_num_bytes_written = 0;
 
   // check for a comm error (clears any error flag present)
-  if (!ClearCommError(serial->fd, &err, NULL)) {
-    *error = error_construct("checking for/clearing comm error failed during serial port write");
-    return;
+  if (!ClearCommError(_state->fd, &err, NULL)) {
+    throw Error{"checking for/clearing comm error failed during serial port write"};
   }
   // in the event of a comm error, purge before writing
   if (err > 0) {
-    if (!PurgeComm(serial->fd, PURGE_TXABORT | PURGE_TXCLEAR)) {
-      *error = error_construct("purging tx buffer failed during serial port write");
-      return;
+    if (!PurgeComm(_state->fd, PURGE_TXABORT | PURGE_TXCLEAR)) {
+      throw Error{"purging tx buffer failed during serial port write"};
     }
   }
 
   // write bytes until "len" bytes have been written
   while (tx_written < (DWORD)len) {
-    if (!WriteFile(serial->fd,                                           // Handle to the Serial port
+    if (!WriteFile(_state->fd,                                           // Handle to the Serial port
                    (const unsigned char*)from + total_num_bytes_written, // Data to be written to the port
                    len - total_num_bytes_written,                        // No of bytes to write
                    &tx_written,                                          // Bytes written
-                   &(serial->wo_))) {
-      *error = error_construct("writing to serial device failed");
-      return;
+                   &(_state->wo_))) {
+      throw Error{"writing to serial device failed"};
     }
     total_num_bytes_written += tx_written;
   }
 
   SWEEP_ASSERT((total_num_bytes_written == (DWORD)len) && "reliable write failed to write requested number of bytes");
   if (total_num_bytes_written != (DWORD)len)
-    *error = error_construct("writing to serial device failed");
+    throw Error{"writing to serial device failed"};
 }
 
-void device_flush(device_s serial, error_s* error) {
-  SWEEP_ASSERT(serial);
-  SWEEP_ASSERT(error);
+void Device::flush() {
 
   DWORD err = 0;
   // check for a comm error (clears any error flag present)
-  if (!ClearCommError(serial->fd, &err, NULL)) {
-    *error = error_construct("checking for/clearing comm error failed during serial port flush");
-    return;
+  if (!ClearCommError(_state->fd, &err, NULL)) {
+    throw Error{"checking for/clearing comm error failed during serial port flush"};
   }
 
   // flush serial port
   // - Empty Tx and Rx buffers
   // - Abort any pending read/write operations
-  if (!PurgeComm(serial->fd, PURGE_RXABORT | PURGE_TXABORT | PURGE_RXCLEAR | PURGE_TXCLEAR)) {
-    *error = error_construct("flushing serial port failed");
+  if (!PurgeComm(_state->fd, PURGE_RXABORT | PURGE_TXABORT | PURGE_RXCLEAR | PURGE_TXCLEAR)) {
+    throw Error{"flushing serial port failed"};
   }
 }
 

--- a/libsweep/serial_win.cc
+++ b/libsweep/serial_win.cc
@@ -1,0 +1,291 @@
+#include "serial.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
+#include <string>
+
+#include <windows.h>
+
+namespace sweep {
+namespace serial {
+
+typedef struct error {
+  const char* what; // always literal, do not free
+} error;
+
+typedef struct device {
+  HANDLE fd;
+  OVERLAPPED ro_;
+  OVERLAPPED wo_;
+} device;
+
+// Constructor hidden from users
+static error_s error_construct(const char* what) {
+  SWEEP_ASSERT(what);
+
+  auto out = new error{what};
+  return out;
+}
+
+const char* error_message(error_s error) {
+  SWEEP_ASSERT(error);
+
+  return error->what;
+}
+
+void error_destruct(error_s error) {
+  SWEEP_ASSERT(error);
+
+  delete error;
+}
+
+static int32_t detail_get_port_number(const char* port, error_s* error) {
+  SWEEP_ASSERT(port);
+  SWEEP_ASSERT(error);
+
+  if (strlen(port) <= 3) {
+    *error = error_construct("invalid port name");
+    return -1;
+  }
+
+  char* end;
+  long parsed_int = std::strtoll(port + 3, &end, 10);
+
+  if (parsed_int >= 0 && parsed_int <= 255)
+    return parsed_int;
+
+  *error = error_construct("invalid port name");
+  return -1;
+}
+
+device_s device_construct(const char* port, int32_t bitrate, error_s* error) {
+  SWEEP_ASSERT(port);
+  SWEEP_ASSERT(bitrate > 0);
+  SWEEP_ASSERT(error);
+
+  if (bitrate != 115200) {
+    *error = error_construct("baud rate is not supported");
+    return nullptr;
+  }
+
+  // read port number from the port name
+  error_s port_num_error = nullptr;
+  int port_num = detail_get_port_number(port, &port_num_error);
+
+  if (port_num_error) {
+    *error = port_num_error;
+    return nullptr;
+  }
+
+  // Construct formal serial port name
+  std::string port_name{"\\\\.\\COM"};
+  port_name += std::to_string(port_num);
+
+  // try to open the port
+  auto hComm = CreateFile(port_name.c_str(),            // port name
+                          GENERIC_READ | GENERIC_WRITE, // read/write
+                          0,                            // No Sharing (serial ports can't be shared)
+                          NULL,                         // No Security
+                          OPEN_EXISTING,                // Open existing port only
+                          0,                            // Non Overlapped I/O
+                          NULL);                        // Null for serial ports
+
+  if (hComm == INVALID_HANDLE_VALUE) {
+    *error = error_construct("opening serial port failed");
+    return nullptr;
+  }
+
+  // retrieve the current comm state
+  DCB dcb_serial_params;
+  dcb_serial_params.DCBlength = sizeof(dcb_serial_params);
+  if (!GetCommState(hComm, &dcb_serial_params)) {
+    *error = error_construct("retrieving current serial port state failed");
+    CloseHandle(hComm);
+    return nullptr;
+  }
+
+  // set the parameters to match the uART settings from the Sweep Comm Protocol
+  dcb_serial_params.BaudRate = CBR_115200; // BaudRate = 115200 (115.2kb/s)
+  dcb_serial_params.ByteSize = 8;          // ByteSize = 8
+  dcb_serial_params.StopBits = ONESTOPBIT; // # StopBits = 1
+  dcb_serial_params.Parity = NOPARITY;     // Parity = None
+  dcb_serial_params.fDtrControl = DTR_CONTROL_DISABLE;
+
+  // set the serial port parameters to the specified values
+  if (!SetCommState(hComm, &dcb_serial_params)) {
+    *error = error_construct("setting serial port parameters failed");
+    CloseHandle(hComm);
+    return nullptr;
+  }
+
+  // specify timeouts (all values in milliseconds)
+  COMMTIMEOUTS timeouts;
+  if (!GetCommTimeouts(hComm, &timeouts)) {
+    *error = error_construct("retrieving current serial port timeouts failed");
+    CloseHandle(hComm);
+    return nullptr;
+  }
+  timeouts.ReadIntervalTimeout = 50;         // max time between arrival of two bytes before ReadFile() returns
+  timeouts.ReadTotalTimeoutConstant = 50;    // used to calculate total time-out period for read operations
+  timeouts.ReadTotalTimeoutMultiplier = 10;  // used to calculate total time-out period for read operations
+  timeouts.WriteTotalTimeoutConstant = 50;   // used to calculate total time-out period for write operations
+  timeouts.WriteTotalTimeoutMultiplier = 10; // used to calculate total time-out period for write operations
+
+  // set the timeouts
+  if (!SetCommTimeouts(hComm, &timeouts)) {
+    *error = error_construct("setting serial port timeouts failed");
+    CloseHandle(hComm);
+    return nullptr;
+  }
+
+  // create the overlapped os reader
+  OVERLAPPED os_reader = {0};
+  OVERLAPPED os_write = {0};
+
+  // Create the overlapped read event. Must be closed before exiting
+  os_reader.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+  if (os_reader.hEvent == NULL) {
+    *error = error_construct("creating overlapped read event failed");
+    CloseHandle(hComm);
+    return nullptr;
+  }
+  // Create the overlapped write event. Must be closed before exiting
+  os_write.hEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
+  if (os_write.hEvent == NULL) {
+    *error = error_construct("creating overlapped write event failed");
+    CloseHandle(hComm);
+    return nullptr;
+  }
+
+  // set the comm mask
+  if (!SetCommMask(hComm, EV_RXCHAR | EV_ERR)) {
+    *error = error_construct("setting comm mask failed");
+    CloseHandle(hComm);
+    CloseHandle(os_reader.hEvent);
+    CloseHandle(os_write.hEvent);
+    return nullptr;
+  }
+
+  // purge the comm port of any pre-existing data or errors
+  if (!PurgeComm(hComm, PURGE_RXABORT | PURGE_TXABORT | PURGE_RXCLEAR | PURGE_TXCLEAR)) {
+    *error = error_construct("flushing serial port failed during serial device construction");
+    CloseHandle(hComm);
+    CloseHandle(os_reader.hEvent);
+    CloseHandle(os_write.hEvent);
+    return nullptr;
+  }
+
+  // create the serial device
+  auto out = new device{hComm, os_reader, os_write};
+
+  return out;
+}
+
+void device_destruct(device_s serial) {
+  SWEEP_ASSERT(serial);
+
+  error_s ignore = nullptr;
+  device_flush(serial, &ignore);
+
+  // close the serial port
+  CloseHandle(serial->fd);
+
+  // close the overlapped read event
+  CloseHandle(serial->ro_.hEvent);
+
+  // close the overlapped write event
+  CloseHandle(serial->wo_.hEvent);
+
+  (void)ignore; // nothing we can do here
+
+  delete serial;
+}
+
+void device_read(device_s serial, void* to, int32_t len, error_s* error) {
+  SWEEP_ASSERT(serial);
+  SWEEP_ASSERT(to);
+  SWEEP_ASSERT(len >= 0);
+  SWEEP_ASSERT(error);
+
+  DWORD rx_read = 0;
+  DWORD total_num_bytes_read = 0;
+
+  // read bytes until "len" bytes have been read
+  while (total_num_bytes_read < (DWORD)len) {
+
+    if (!ReadFile(serial->fd, (unsigned char*)to + total_num_bytes_read, len - total_num_bytes_read, &rx_read, &(serial->ro_))) {
+      *error = error_construct("reading from serial device failed");
+      return;
+    }
+    total_num_bytes_read += rx_read;
+  }
+
+  SWEEP_ASSERT(total_num_bytes_read == (DWORD)len && "reliable read failed to read requested number of bytes");
+  if (total_num_bytes_read != (DWORD)len)
+    *error = error_construct("reading from serial device failed");
+}
+
+void device_write(device_s serial, const void* from, int32_t len, error_s* error) {
+  SWEEP_ASSERT(serial);
+  SWEEP_ASSERT(from);
+  SWEEP_ASSERT(len >= 0);
+  SWEEP_ASSERT(error);
+
+  DWORD err = 0;
+  DWORD tx_written = 0;
+  DWORD total_num_bytes_written = 0;
+
+  // check for a comm error (clears any error flag present)
+  if (!ClearCommError(serial->fd, &err, NULL)) {
+    *error = error_construct("checking for/clearing comm error failed during serial port write");
+    return;
+  }
+  // in the event of a comm error, purge before writing
+  if (err > 0) {
+    if (!PurgeComm(serial->fd, PURGE_TXABORT | PURGE_TXCLEAR)) {
+      *error = error_construct("purging tx buffer failed during serial port write");
+      return;
+    }
+  }
+
+  // write bytes until "len" bytes have been written
+  while (tx_written < (DWORD)len) {
+    if (!WriteFile(serial->fd,                                           // Handle to the Serial port
+                   (const unsigned char*)from + total_num_bytes_written, // Data to be written to the port
+                   len - total_num_bytes_written,                        // No of bytes to write
+                   &tx_written,                                          // Bytes written
+                   &(serial->wo_))) {
+      *error = error_construct("writing to serial device failed");
+      return;
+    }
+    total_num_bytes_written += tx_written;
+  }
+
+  SWEEP_ASSERT((total_num_bytes_written == (DWORD)len) && "reliable write failed to write requested number of bytes");
+  if (total_num_bytes_written != (DWORD)len)
+    *error = error_construct("writing to serial device failed");
+}
+
+void device_flush(device_s serial, error_s* error) {
+  SWEEP_ASSERT(serial);
+  SWEEP_ASSERT(error);
+
+  DWORD err = 0;
+  // check for a comm error (clears any error flag present)
+  if (!ClearCommError(serial->fd, &err, NULL)) {
+    *error = error_construct("checking for/clearing comm error failed during serial port flush");
+    return;
+  }
+
+  // flush serial port
+  // - Empty Tx and Rx buffers
+  // - Abort any pending read/write operations
+  if (!PurgeComm(serial->fd, PURGE_RXABORT | PURGE_TXABORT | PURGE_RXCLEAR | PURGE_TXCLEAR)) {
+    *error = error_construct("flushing serial port failed");
+  }
+}
+
+} // ns serial
+} // ns sweep

--- a/libsweep/sweep.cc
+++ b/libsweep/sweep.cc
@@ -1,30 +1,10 @@
 #include "sweep.h"
-#include "protocol.h"
-#include "serial.h"
-
-#include <chrono>
-#include <thread>
+#include "sweep_device.hpp"
 
 int32_t sweep_get_version(void) { return SWEEP_VERSION; }
 bool sweep_is_abi_compatible(void) { return sweep_get_version() >> 16u == SWEEP_VERSION_MAJOR; }
 
-typedef struct sweep_error {
-  const char* what; // always literal, do not deallocate
-} sweep_error;
-
-typedef struct sweep_device {
-  sweep::serial::device_s serial; // serial port communication
-  bool is_scanning;
-} sweep_device;
-
-#define SWEEP_MAX_SAMPLES 4096
-
-typedef struct sweep_scan {
-  int32_t angle[SWEEP_MAX_SAMPLES];           // in millidegrees
-  int32_t distance[SWEEP_MAX_SAMPLES];        // in cm
-  int32_t signal_strength[SWEEP_MAX_SAMPLES]; // range 0:255
-  int32_t count;
-} sweep_scan;
+typedef struct sweep_error { const char* what; } sweep_error;
 
 // Constructor hidden from users
 static sweep_error_s sweep_error_construct(const char* what) {
@@ -42,8 +22,32 @@ const char* sweep_error_message(sweep_error_s error) {
 
 void sweep_error_destruct(sweep_error_s error) {
   SWEEP_ASSERT(error);
-
   delete error;
+}
+
+template <class F> auto translateException(F&& f, sweep_error_s* error) -> decltype(std::forward<F>(f)()) {
+  try {
+    return std::forward<F>(f)();
+  } catch (const sweep::ErrorBase& e) {
+    *error = sweep_error_construct(e.what());
+  } catch (const std::bad_alloc&) {
+    *error = sweep_error_construct("Could not allocate enough memory");
+  } catch (...) {
+    *error = sweep_error_construct("Unknown exception");
+  }
+  return {};
+}
+
+template <class F> void translateExceptionV(F&& f, sweep_error_s* error) {
+  try {
+    std::forward<F>(f)();
+  } catch (const sweep::ErrorBase& e) {
+    *error = sweep_error_construct(e.what());
+  } catch (const std::bad_alloc&) {
+    *error = sweep_error_construct("Could not allocate enough memory");
+  } catch (...) {
+    *error = sweep_error_construct("Unknown exception");
+  }
 }
 
 sweep_device_s sweep_device_construct_simple(sweep_error_s* error) {
@@ -56,169 +60,32 @@ sweep_device_s sweep_device_construct(const char* port, int32_t bitrate, sweep_e
   SWEEP_ASSERT(port);
   SWEEP_ASSERT(bitrate > 0);
   SWEEP_ASSERT(error);
-
-  sweep::serial::error_s serialerror = nullptr;
-  sweep::serial::device_s serial = sweep::serial::device_construct(port, bitrate, &serialerror);
-
-  if (serialerror) {
-    *error = sweep_error_construct(sweep::serial::error_message(serialerror));
-    sweep::serial::error_destruct(serialerror);
-    return nullptr;
-  }
-
-  auto out = new sweep_device{serial, /*is_scanning=*/true};
-
-  sweep_error_s stoperror = nullptr;
-  sweep_device_stop_scanning(out, &stoperror);
-
-  if (stoperror) {
-    *error = stoperror;
-    sweep_device_destruct(out);
-    return nullptr;
-  }
-
-  return out;
+  return translateException([&] { return new sweep_device{port, bitrate}; }, error);
 }
 
 void sweep_device_destruct(sweep_device_s device) {
   SWEEP_ASSERT(device);
-
-  sweep_error_s ignore = nullptr;
-  sweep_device_stop_scanning(device, &ignore);
-  (void)ignore; // nothing we can do here
-
-  sweep::serial::device_destruct(device->serial);
-
   delete device;
 }
 
 void sweep_device_start_scanning(sweep_device_s device, sweep_error_s* error) {
   SWEEP_ASSERT(device);
   SWEEP_ASSERT(error);
-
-  if (device->is_scanning)
-    return;
-
-  sweep::protocol::error_s protocolerror = nullptr;
-  sweep::protocol::write_command(device->serial, sweep::protocol::DATA_ACQUISITION_START, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to send start scanning command");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
-
-  sweep::protocol::response_header_s response;
-  sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_START, &response, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to receive start scanning command response");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
-
-  device->is_scanning = true;
+  translateExceptionV([&] { return device->start_scanning(); }, error);
 }
 
 void sweep_device_stop_scanning(sweep_device_s device, sweep_error_s* error) {
   SWEEP_ASSERT(device);
   SWEEP_ASSERT(error);
 
-  if (!device->is_scanning)
-    return;
-
-  sweep::protocol::error_s protocolerror = nullptr;
-  sweep::protocol::write_command(device->serial, sweep::protocol::DATA_ACQUISITION_STOP, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to send stop scanning command");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
-
-  // Wait until device stopped sending
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-
-  sweep::serial::error_s serialerror = nullptr;
-  sweep::serial::device_flush(device->serial, &serialerror);
-
-  if (serialerror) {
-    *error = sweep_error_construct("unable to flush serial device for stopping scanning command");
-    sweep::serial::error_destruct(serialerror);
-    return;
-  }
-
-  sweep::protocol::write_command(device->serial, sweep::protocol::DATA_ACQUISITION_STOP, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to send stop scanning command");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
-
-  sweep::protocol::response_header_s response;
-  sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_STOP, &response, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to receive stop scanning command response");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
-
-  device->is_scanning = false;
+  translateExceptionV([&] { return device->stop_scanning(); }, error);
 }
 
 sweep_scan_s sweep_device_get_scan(sweep_device_s device, sweep_error_s* error) {
   SWEEP_ASSERT(device);
   SWEEP_ASSERT(error);
 
-  sweep::protocol::error_s protocolerror = nullptr;
-
-  sweep::protocol::response_scan_packet_s responses[SWEEP_MAX_SAMPLES];
-
-  int32_t first = 0;
-  int32_t last = SWEEP_MAX_SAMPLES;
-
-  for (int32_t received = 0; received < SWEEP_MAX_SAMPLES; ++received) {
-    sweep::protocol::read_response_scan(device->serial, &responses[received], &protocolerror);
-
-    if (protocolerror) {
-      *error = sweep_error_construct("unable to receive sweep scan response");
-      sweep::protocol::error_destruct(protocolerror);
-      return nullptr;
-    }
-
-    // Only gather a full scan. We could improve this logic to improve on throughput
-    // with complicating the code much more (think spsc queue of all responses).
-    // On the other hand, we could also discard the sync bit and check repeating angles.
-    if (responses[received].sync_error == 1) {
-      if (first != 0 && last == SWEEP_MAX_SAMPLES) {
-        last = received;
-        break;
-      }
-
-      if (first == 0 && last == SWEEP_MAX_SAMPLES) {
-        first = received;
-      }
-    }
-  }
-
-  auto out = new sweep_scan;
-
-  SWEEP_ASSERT(last - first >= 0);
-  SWEEP_ASSERT(last - first < SWEEP_MAX_SAMPLES);
-
-  out->count = last - first;
-
-  for (int32_t it = 0; it < last - first; ++it) {
-    // Convert angle from compact serial format to float (in degrees).
-    // In addition convert from degrees to milli-degrees.
-    out->angle[it] = sweep::protocol::u16_to_f32(responses[first + it].angle) * 1000.f;
-    out->distance[it] = responses[first + it].distance;
-    out->signal_strength[it] = responses[first + it].signal_strength;
-  }
-
-  return out;
+  return translateException([&] { return device->get_scan(); }, error);
 }
 
 int32_t sweep_scan_get_number_of_samples(sweep_scan_s scan) {
@@ -259,28 +126,7 @@ int32_t sweep_device_get_motor_speed(sweep_device_s device, sweep_error_s* error
   SWEEP_ASSERT(device);
   SWEEP_ASSERT(error);
 
-  sweep::protocol::error_s protocolerror = nullptr;
-
-  sweep::protocol::write_command(device->serial, sweep::protocol::MOTOR_INFORMATION, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to send motor speed command");
-    sweep::protocol::error_destruct(protocolerror);
-    return 0;
-  }
-
-  sweep::protocol::response_info_motor_s response;
-  sweep::protocol::read_response_info_motor(device->serial, sweep::protocol::MOTOR_INFORMATION, &response, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to receive motor speed command response");
-    sweep::protocol::error_destruct(protocolerror);
-    return 0;
-  }
-
-  int32_t speed = sweep::protocol::ascii_bytes_to_speed(response.motor_speed);
-
-  return speed;
+  return translateException([&] { return device->get_motor_speed(); }, error);
 }
 
 void sweep_device_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error_s* error) {
@@ -288,40 +134,12 @@ void sweep_device_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error
   SWEEP_ASSERT(hz >= 0 && hz <= 10);
   SWEEP_ASSERT(error);
 
-  uint8_t args[2] = {0};
-  sweep::protocol::speed_to_ascii_bytes(hz, args);
-
-  sweep::protocol::error_s protocolerror = nullptr;
-
-  sweep::protocol::write_command_with_arguments(device->serial, sweep::protocol::MOTOR_SPEED_ADJUST, args, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to send motor speed command");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
-
-  sweep::protocol::response_param_s response;
-  sweep::protocol::read_response_param(device->serial, sweep::protocol::MOTOR_SPEED_ADJUST, &response, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to receive motor speed command response");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
+  translateExceptionV([&] { return device->set_motor_speed(hz); }, error);
 }
 
 void sweep_device_reset(sweep_device_s device, sweep_error_s* error) {
   SWEEP_ASSERT(device);
   SWEEP_ASSERT(error);
 
-  sweep::protocol::error_s protocolerror = nullptr;
-
-  sweep::protocol::write_command(device->serial, sweep::protocol::RESET_DEVICE, &protocolerror);
-
-  if (protocolerror) {
-    *error = sweep_error_construct("unable to send device reset command");
-    sweep::protocol::error_destruct(protocolerror);
-    return;
-  }
+  translateExceptionV([&] { return device->reset(); }, error);
 }

--- a/libsweep/sweep.h
+++ b/libsweep/sweep.h
@@ -10,11 +10,11 @@ extern "C" {
 
 #if __GNUC__ >= 4
 #define SWEEP_API __attribute__((visibility("default")))
-#define SWEEP_PACKED __attribute__((packed))
+#elif _MSC_VER >= 1900
+#define SWEEP_API
 #else
 #error "Only Clang and GCC supported at the moment, please open a ticket"
 #define SWEEP_API
-#define SWEEP_PACKED
 #endif
 
 #define SWEEP_VERSION_MAJOR 0

--- a/libsweep/sweep_device.hpp
+++ b/libsweep/sweep_device.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "protocol.h"
+#include "serial.h"
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "sweep.h"
+#include "sweep_device.hpp"
+
+#define SWEEP_MAX_SAMPLES 4096
+
+struct sweep_scan {
+  int32_t angle[SWEEP_MAX_SAMPLES];           // in millidegrees
+  int32_t distance[SWEEP_MAX_SAMPLES];        // in cm
+  int32_t signal_strength[SWEEP_MAX_SAMPLES]; // range 0:255
+  int32_t count;
+};
+
+struct sweep_device {
+public:
+  sweep_device();
+  sweep_device(const char* port, int32_t bitrate);
+  ~sweep_device();
+
+  void start_scanning();
+  void stop_scanning();
+
+  sweep_scan_s get_scan();
+
+  int32_t get_motor_speed();
+  void set_motor_speed(int32_t hz);
+
+  void reset();
+
+private:
+  sweep::serial::Device serial; // serial port communication
+  bool is_scanning;
+};
+
+sweep_device::sweep_device() : sweep_device("/dev/ttyUSB0", 115200) {}
+
+sweep_device::sweep_device(const char* port, int32_t bitrate) : serial{port, bitrate}, is_scanning{true} {
+  SWEEP_ASSERT(port);
+  SWEEP_ASSERT(bitrate > 0);
+  stop_scanning();
+}
+
+sweep_device::~sweep_device() {
+  try {
+    stop_scanning();
+  } catch (...) {
+  }
+}
+
+void sweep_device::start_scanning() {
+  if (is_scanning)
+    return;
+
+  sweep::protocol::write_command(serial, sweep::protocol::DATA_ACQUISITION_START);
+  sweep::protocol::read_response_header(serial, sweep::protocol::DATA_ACQUISITION_START);
+
+  is_scanning = true;
+}
+
+void sweep_device::stop_scanning() {
+  if (!is_scanning)
+    return;
+
+  sweep::protocol::write_command(serial, sweep::protocol::DATA_ACQUISITION_STOP);
+
+  // Wait until device stopped sending
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  serial.flush();
+  sweep::protocol::write_command(serial, sweep::protocol::DATA_ACQUISITION_STOP);
+  sweep::protocol::read_response_header(serial, sweep::protocol::DATA_ACQUISITION_STOP);
+  is_scanning = false;
+}
+
+sweep_scan_s sweep_device::get_scan() {
+  sweep::protocol::response_scan_packet_s responses[SWEEP_MAX_SAMPLES];
+
+  int32_t first = 0;
+  int32_t last = SWEEP_MAX_SAMPLES;
+
+  for (int32_t received = 0; received < SWEEP_MAX_SAMPLES; ++received) {
+
+    sweep::protocol::read_response_scan(serial, &responses[received]);
+
+    // Only gather a full scan. We could improve this logic to improve on throughput
+    // with complicating the code much more (think spsc queue of all responses).
+    // On the other hand, we could also discard the sync bit and check repeating angles.
+    if (responses[received].sync_error == 1) {
+      if (first != 0 && last == SWEEP_MAX_SAMPLES) {
+        last = received;
+        break;
+      }
+
+      if (first == 0 && last == SWEEP_MAX_SAMPLES) {
+        first = received;
+      }
+    }
+  }
+
+  auto out = new sweep_scan;
+
+  SWEEP_ASSERT(last - first >= 0);
+  SWEEP_ASSERT(last - first < SWEEP_MAX_SAMPLES);
+
+  out->count = last - first;
+
+  for (int32_t it = 0; it < last - first; ++it) {
+    // Convert angle from compact serial format to float (in degrees).
+    // In addition convert from degrees to milli-degrees.
+    out->angle[it] = static_cast<int32_t>(sweep::protocol::u16_to_f32(responses[first + it].angle) * 1000.f);
+    out->distance[it] = responses[first + it].distance;
+    out->signal_strength[it] = responses[first + it].signal_strength;
+  }
+
+  return out;
+}
+
+int32_t sweep_device::get_motor_speed() {
+  sweep::protocol::write_command(serial, sweep::protocol::MOTOR_INFORMATION);
+
+  auto response = sweep::protocol::read_response_info_motor(serial, sweep::protocol::MOTOR_INFORMATION);
+  int32_t speed = sweep::protocol::ascii_bytes_to_speed(response.motor_speed);
+
+  return speed;
+}
+
+void sweep_device::set_motor_speed(int32_t hz) {
+  SWEEP_ASSERT(hz >= 0 && hz <= 10);
+
+  uint8_t args[2] = {0};
+  sweep::protocol::speed_to_ascii_bytes(hz, args);
+
+  sweep::protocol::write_command_with_arguments(serial, sweep::protocol::MOTOR_SPEED_ADJUST, args);
+  sweep::protocol::read_response_param(serial, sweep::protocol::MOTOR_SPEED_ADJUST);
+}
+
+void sweep_device::reset() { sweep::protocol::write_command(serial, sweep::protocol::RESET_DEVICE); }


### PR DESCRIPTION
This is more a prove of concept than a real PR, but it demonstrates how exceptions could be used to simplify the code as discussed in issue #9.

Unfortunately, this is a quite pervasive change and additionally intertwined with a few other changes I made on the way (see comment on last commit). So I don't know if merging it is realistic but it should give you an impression of what it could look like.

In any case, please note that a solution like this will not produce the same error messages as before, because I omitted the translation step when an error bubbles up. You could do this with exceptions by adding a try, catch and rethrow block everywhere but that would essentially eliminate the advantage of using exceptions in the first place.