### PR TITLE
Adds sweep-ctl, resolves #49

### DIFF
--- a/libsweep/CMakeLists.txt
+++ b/libsweep/CMakeLists.txt
@@ -75,6 +75,17 @@ install(DIRECTORY include/sweep DESTINATION include)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/sweep/config.h DESTINATION include/sweep)
 
 
+# sweep-ctl target.
+
+
+add_executable(sweep-ctl src/sweep-ctl.cc)
+target_include_directories(sweep-ctl PRIVATE include include/sweep ${CMAKE_CURRENT_BINARY_DIR}/include)
+target_link_libraries(sweep-ctl sweep ${CMAKE_THREAD_LIBS_INIT})
+
+include(GNUInstallDirs)
+install(TARGETS sweep-ctl DESTINATION bin)
+install(FILES man/sweep-ctl.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+
 # Make FindPackage(Sweep) work for CMake users.
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/SweepConfig.cmake DESTINATION lib/cmake/sweep)
 

--- a/libsweep/include/sweep/sweep.hpp
+++ b/libsweep/include/sweep/sweep.hpp
@@ -17,7 +17,7 @@
 #include <stdexcept>
 #include <vector>
 
-#include "sweep.h"
+#include <sweep/sweep.h>
 
 namespace sweep {
 
@@ -121,7 +121,7 @@ scan sweep::get_scan() {
   }
 
   return result;
-};
+}
 
 void sweep::reset() { ::sweep_device_reset(device.get(), detail::error_to_exception{}); }
 

--- a/libsweep/man/build.sh
+++ b/libsweep/man/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Builds man pages from markdown files.
+# Usage: ./build.sh page.md page.1
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [ $# -ne 2 ]; then
+    exit 1
+fi
+
+pandoc --standalone "${1}" --output "${2}"

--- a/libsweep/man/sweep-ctl.1
+++ b/libsweep/man/sweep-ctl.1
@@ -1,0 +1,45 @@
+.TH "sweep\-ctl" "1" "February 18, 2017" "User Manuals" ""
+.SH NAME
+.PP
+sweep\-ctl \- get and set Sweep LiDAR hardware properties
+.SH SYNOPSIS
+.PP
+sweep\-ctl dev get|set key [value]
+.SH DESCRIPTION
+.PP
+Command line tool to interact with the Sweep LiDAR device.
+.SH OPTIONS
+.TP
+.B get property
+Returns value currently set for property.
+.RS
+.RE
+.TP
+.B set property value
+Sets value for property.
+.RS
+.RE
+.SH PROPERTIES
+.TP
+.B motor_speed
+The device\[aq]s motor speed in Hz.
+.RS
+.RE
+.TP
+.B sample_rate
+The device\[aq]s sample rate in Hz.
+.RS
+.RE
+.SH EXAMPLE
+.IP
+.nf
+\f[C]
+$\ sweep\-ctl\ /dev/ttyUSB0\ get\ motor_speed
+3
+
+$\ sweep\-ctl\ /dev/ttyUSB0\ set\ motor_speed\ 5
+5
+\f[]
+.fi
+.SH AUTHORS
+Daniel Hofmann.

--- a/libsweep/man/sweep-ctl.md
+++ b/libsweep/man/sweep-ctl.md
@@ -1,0 +1,39 @@
+% sweep-ctl(1) User Manuals
+% Daniel Hofmann
+% February 18, 2017
+
+# NAME
+
+sweep-ctl - get and set Sweep LiDAR hardware properties
+
+# SYNOPSIS
+
+sweep-ctl dev get|set key [value]
+
+# DESCRIPTION
+
+Command line tool to interact with the Sweep LiDAR device.
+
+# OPTIONS
+
+get property
+:   Returns value currently set for property.
+
+set property value
+:    Sets value for property.
+
+# PROPERTIES
+
+motor\_speed
+:    The device's motor speed in Hz.
+
+sample\_rate
+:    The device's sample rate in Hz.
+
+# EXAMPLE
+
+    $ sweep-ctl /dev/ttyUSB0 get motor_speed
+    3
+
+    $ sweep-ctl /dev/ttyUSB0 set motor_speed 5
+    5

--- a/libsweep/src/sweep-ctl.cc
+++ b/libsweep/src/sweep-ctl.cc
@@ -1,0 +1,59 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+
+#include <string>
+#include <vector>
+
+#include <sweep/sweep.hpp>
+
+static const auto kMotorSpeedCmd = "motor_speed";
+static const auto kSampleRateCmd = "sample_rate";
+
+static void usage() {
+  std::fprintf(stderr, "sweep-ctl dev get|set key [value]\n");
+  std::exit(EXIT_FAILURE);
+}
+
+int main(int argc, char** argv) try {
+  std::vector<std::string> args{argv, argv + argc};
+
+  const auto get = args.size() == 4 && args[2] == "get";
+  const auto set = args.size() == 5 && args[2] == "set";
+
+  if (!get && !set)
+    usage();
+
+  const auto& dev = args[1];
+  const auto& cmd = args[3];
+
+  sweep::sweep device{dev.c_str(), 115200}; // TODO: simple dev ctor
+
+  if (get && cmd == kMotorSpeedCmd) {
+    std::printf("%" PRId32 "\n", device.get_motor_speed());
+    return EXIT_SUCCESS;
+  }
+
+  if (get && cmd == kSampleRateCmd) {
+    std::printf("%" PRId32 "\n", device.get_sample_rate());
+    return EXIT_SUCCESS;
+  }
+
+  if (set && cmd == kMotorSpeedCmd) {
+    device.set_motor_speed(std::stoi(args[4]));
+    std::printf("%" PRId32 "\n", device.get_motor_speed());
+    return EXIT_SUCCESS;
+  }
+
+  if (set && cmd == kSampleRateCmd) {
+    device.set_sample_rate(std::stoi(args[4]));
+    std::printf("%" PRId32 "\n", device.get_sample_rate());
+    return EXIT_SUCCESS;
+  }
+
+  usage();
+
+} catch (const std::exception& e) {
+  std::fprintf(stderr, "Error: %s\n", e.what());
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
Adds a `sweep-ctl` binary as described in #49.

Not sure about the man page install dir on macOS and Windows. At the moment I'm using CMake's `GNUInstallDirs` module. Would be great if we can check this first before merging.