### PR TITLE
sweeppy: fix Python 3 compatibility

### DIFF
--- a/sweeppy/sweeppy/__init__.py
+++ b/sweeppy/sweeppy/__init__.py
@@ -69,7 +69,7 @@ def _error_to_exception(error):
     assert error
     what = libsweep.sweep_error_message(error)
     libsweep.sweep_error_destruct(error)
-    return RuntimeError(what)
+    return RuntimeError(what.decode('ascii'))
 
 
 class Scan(collections.namedtuple('Scan', 'samples')):
@@ -99,11 +99,11 @@ class Sweep:
         assert simple or config, 'No arguments for bitrate, required'
 
         if simple:
-            port = ctypes.string_at(_.args[0])
+            port = ctypes.string_at(_.args[0].encode('ascii'))
             device = libsweep.sweep_device_construct_simple(port, ctypes.byref(error))
 
         if config:
-            port = ctypes.string_at(_.args[0])
+            port = ctypes.string_at(_.args[0].encode('ascii'))
             bitrate = ctypes.c_int32(_.args[1])
             device = libsweep.sweep_device_construct(port, bitrate, ctypes.byref(error))
 


### PR DESCRIPTION
Rationale: `ctypes.c_char_p` map C `char*` to Python byte objects.
Thus, encoding Python strings is required before passing it as argument.

This fixes a `opening serial port failed` problem when using Python 3.