### PR TITLE
Adds Docker Integration for SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:3.5
+
+RUN mkdir -p /opt/sweep-sdk
+COPY . /opt/sweep-sdk
+WORKDIR /opt/sweep-sdk
+
+RUN apk --no-cache add cmake make gcc g++ zeromq protobuf python2 python3 nodejs && \
+    cd libsweep && \
+    mkdir build && \
+    cd build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build . && \
+    cmake --build . --target install && \
+    cd ../../ && \
+    cd sweeppy && \
+    python2 -m ensurepip && \
+    python3 -m ensurepip && \
+    pip2 install setuptools && \
+    pip3 install setuptools && \
+    python2 setup.py install && \
+    python3 setup.py install && \
+    cd .. && \
+    cd sweepjs && \
+    npm install --unsafe-perm

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ SDK for Scanse Sweep LiDAR.
 - [SweepPy](sweeppy/README.md): Python bindings
 - [SweepJs](sweepjs/README.md): NodeJS bindings
 
+In addition you can use the `scanse/sweep-sdk` Docker image which bundles up the SDK.
+
+    docker run --device /dev/ttyUSB0:/dev/ttyUSB0 -it scanse/sweep-sdk /bin/sh
+
 Real-time viewer for a device speed of 5 Hz:
 
 ![viewer](https://cloud.githubusercontent.com/assets/527241/20300444/92ade432-ab1f-11e6-9d96-a585df3fe471.png)


### PR DESCRIPTION
This adds a `Dockerfile` bundling the development files, headers and basically everything you need to quick-start development with the Sweep device. What I want is Docker Hub automatically building images for every commit / tag / release and then being able to use this as a base image for my apps.