### PR TITLE
Added close serial port to device_destruct in unix serial.cc

### DIFF
--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -353,7 +353,11 @@ void device_destruct(device_s serial) {
 
   error_s ignore = nullptr;
   device_flush(serial, &ignore);
-  close(serial->fd);
+
+  if (close(serial->fd) == -1) {
+      SWEEP_ASSERT(false && "closing file descriptor during destruct failed");
+  }
+
   (void)ignore; // nothing we can do here
 
   delete serial;

--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -353,6 +353,7 @@ void device_destruct(device_s serial) {
 
   error_s ignore = nullptr;
   device_flush(serial, &ignore);
+  close(serial->fd);
   (void)ignore; // nothing we can do here
 
   delete serial;


### PR DESCRIPTION
Serial device was not being properly closed on unix systems. This is ok on windows. 