### PR TITLE
Temp Fix for Delayed Buffering of Stop Response during Device Construction on Raspberry Pi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ This release is compatible with device firmware v1.4.
 
 Changes:
 - libsweep: 
-  - Adapts device construction to be compatible with RaspberryPi (see #73)
+  - Adapts device construction to be compatible with RaspberryPi
   - Removes implementation methods from API
+  - Propagates errors from background thread when accumulating scans
 
 ## v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.1.2
+
+This release is compatible with device firmware v1.4.
+
+Changes:
+- libsweep: 
+  - Adapts device construction to be compatible with RaspberryPi (see #73)
+  - Removes implementation methods from API
 
 ## v1.1.1
 

--- a/libsweep/CMakeLists.txt
+++ b/libsweep/CMakeLists.txt
@@ -6,7 +6,7 @@ project(sweep C CXX)
 
 set(SWEEP_VERSION_MAJOR 1)
 set(SWEEP_VERSION_MINOR 1)
-set(SWEEP_VERSION_PATCH 1)
+set(SWEEP_VERSION_PATCH 2)
 
 
 option(DUMMY "Build dummy libsweep always returning static point cloud data. No device needed." OFF)

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -294,6 +294,7 @@ void sweep_device_stop_scanning(sweep_device_s device, sweep_error_s* error) try
   } catch (const std::exception& ignore) {
     // Catch and ignore the error in the case of the stop response containing garbage bytes
     // Occurs if the device was actively streaming data before the stop cmd
+    (void)ignore;
   }
 
   // Flush any bytes left over, in case device was actively streaming data before the stop cmd

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -279,14 +279,27 @@ void sweep_device_stop_scanning(sweep_device_s device, sweep_error_s* error) try
 
   sweep::protocol::write_command(device->serial, sweep::protocol::DATA_ACQUISITION_STOP);
 
-  // Wait some time, for the device to register the stop cmd and stop sending data blocks
+  // Wait some time for a few reasons:
+  // 1. allow time for the device to register the stop cmd and stop sending data blocks
+  // 2. allow time for slower performing devices (RaspberryPi) to buffer the stop response
+  // 3. allow a grace period for the device to perform its logging routine before sending a second stop command
   std::this_thread::sleep_for(std::chrono::milliseconds(35));
 
-  // Flush the left over data blocks, received after sending the stop cmd
-  // This will also flush the response to the stop cmd
+  // Read the response from the first stop command
+  // It is possible this will contain garbage bytes (leftover from data stream), and will error
+  // But we are guaranteed to read at least as many bytes as the length of a stop response
+  sweep::protocol::response_header_s garbage_response;
+  try {
+    sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_STOP, &garbage_response);
+  } catch (const std::exception& ignore) {
+    // Catch and ignore the error in the case of the stop response containing garbage bytes
+    // Occurs if the device was actively streaming data before the stop cmd
+  }
+
+  // Flush any bytes left over, in case device was actively streaming data before the stop cmd
   sweep::serial::device_flush(device->serial);
 
-  // Write another stop cmd so we can read a response
+  // Write another stop cmd so we can read a valid response
   sweep::protocol::write_command(device->serial, sweep::protocol::DATA_ACQUISITION_STOP);
 
   // read the response

--- a/sweepjs/package.json
+++ b/sweepjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sweepjs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Native module for the Sweep LiDAR",
   "keywords": [
     "addon",


### PR DESCRIPTION
This a temporary solution to the problems described in #73. See the issue for details.

It would be nice to know the root cause of the bug, but this temporary fix will allow development of the 3d-scanner to commence.