### PR TITLE
Added templates for contribution, issues and pull requests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Help 
+The [issues](https://github.com/scanse/sweep-sdk/issues) section is for bug reports and feature requests. If you need help with a project, please use the [community](http://community.scanse.io/) forum.
+
+---
+# Bugs
+#### Before reporting a bug
+
+1. Search [issue tracker](https://github.com/scanse/sweep-sdk/issues) for similar issues.
+2. Make sure you are using the latest version of the library and that you have thoroughly reviewed all provided documentation.
+
+#### How to report a bug
+
+1. Specify the version of the library in use when the bug occurred.
+2. Specify your operating system, platform and any other details you think might be relevant.
+3. Describe the problem in detail. Explain what happened, and what you expected would happen.
+4. If possible, provide a small code-snippet or test-case that reproduces the issue.
+5. If it makes things more clear, include an annotated screenshot.
+
+---
+# Contribution
+We encourage community contribution! We will work hard to integrate valuable changes, improvements and features. To make the process more efficient, here are the general steps to contribute.
+
+#### How to contribute
+
+1. Login or create a GitHub account.
+2. Fork the repository on GitHub.
+3. Make changes to your fork of the repository.
+4. Check the [Contribution Guidelines](PULL_REQUEST_TEMPLATE.md) for pull requests and make sure your modifications adhere to the guidelines.
+5. Submit your modifications as a new pull request [here](https://github.com/scanse/sweep-sdk/pulls).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!---
+This form is intended mainly for bug reports and feature requests. 
+This is NOT the place to ask for general project help. If you need help, please use the community forum available [here](http://community.scanse.io/).
+-->
+
+#### sweep firmware version
+What verison of the sweep firmware are you using?
+- [ ] latest
+- [ ] other (please specify)
+- [ ] Not Applicable
+
+#### libsweep version
+- [ ] latest
+- [ ] other (please specify)
+
+#### relevant library
+- [ ] libsweep
+- [ ] sweeppy
+- [ ] sweepjs
+
+#### operating system
+- [x] All of them
+- [ ] Windows
+- [ ] macOS
+- [ ] Linux
+- [ ] Other (please specify)
+
+#### Platform/Hardware Setup
+Provide any relevant details you can share.
+
+#### Description:
+Describe the bug or feature request in detail. 
+A code snippet, screenshot, and small-test help us understand.
+Explain what happened and what you expected to happen.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+Thank you for creating a pull request. We encourage community contribution to the sweep-sdk!
+Before opening a pull request, please consider the following guidelines. Adhering to these guidelines will help speed up the review process and get your changes integrated more quickly:
+
+- **Describe the scope of any changes made.** What does the Pull Request accomplish? Summarize what parts of the code were modified to implement the change.
+
+- **Describe any known limitations.**  If the change does not yet support a certain feature of the library, or a particular language binding, note that here.
+
+- **Format the modified code.** Please follow the format and conventions of the existing code. For libsweep, a `clang-format` file is included to accomplish this automatically. This can even be integrated with your IDE.
+- **Test the modified code.**  Try to run any and all tests or examples provided with the libraries. Add any examples needed to exercise your modified code.
+
+Thanks again for submitting a Pull Request. We value community contribution and will work hard to integrate your changes as quickly as possible.
+
+Once you have reviewed the provided guidelines, you can delete this text so it does not clutter the pull request.


### PR DESCRIPTION
This PR adds templates for new issues and pull requests. It places templates in a `.github/` directory at the root of repo to avoid clutter. The templates provide general guidelines for contribution. The existing documentation remains untouched.

This was really just a start. We will likely see a rapid pickup in community contribution as backers begin to receive devices. I am open to completely reformatting these templates to provide contributors with necessary information, or to better clarify our policies. 