### PR TITLE
Suppress compiler warning when ignoring exception

### DIFF
--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -236,6 +236,7 @@ void sweep_device_accumulate_scans(sweep_device_s device) try {
   }
 } catch (const std::exception& e) {
   // worker thread is dead at this point
+  (void)e;
 }
 
 bool sweep_device_get_motor_ready(sweep_device_s device, sweep_error_s* error) try {


### PR DESCRIPTION
#### Scope of changes
Gets rid of the following compiler warning:
`warning C4101: 'e' : unreferenced local variable`

Change involves performing a void cast on any exception caught in the worker thread's `accumulate_scans()` method. 


#### Known Limitations
No limitations over the existing code, as currently the exception isn't being used. This will likely be a temporary fix, until a later PR actually propagates the error by notifying the main thread. 