### PR TITLE
[libsweep] Forward errors from accumulate_scans to get_scan

### DIFF
--- a/libsweep/include/queue.hpp
+++ b/libsweep/include/queue.hpp
@@ -10,12 +10,17 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <exception>
 #include <mutex>
 #include <queue>
 #include <utility>
 
 namespace sweep {
 namespace queue {
+
+struct ReadCanceled : std::exception {
+  const char* what() const noexcept override { return "Read was canceled by user"; }
+};
 
 template <typename T> class queue {
 public:
@@ -30,39 +35,55 @@ public:
   }
 
   // Add an element to the queue.
-  void enqueue(T v) {
-    std::lock_guard<std::mutex> lock(the_mutex);
+  void push(T v) {
+    {
+      std::lock_guard<std::mutex> lock(the_mutex);
 
-    // if necessary, remove the oldest scan to make room for new
-    if (static_cast<int32_t>(the_queue.size()) >= max_size)
-      the_queue.pop();
+      // if necessary, remove the oldest scan to make room for new
+      if (static_cast<int32_t>(the_queue.size()) >= max_size)
+        the_queue.pop();
 
-    the_queue.push(v);
+      the_queue.push(v);
+    }
     the_cond_var.notify_one();
   }
 
   // If the queue is empty, wait till an element is avaiable.
-  T dequeue() {
+  T pop() {
     std::unique_lock<std::mutex> lock(the_mutex);
     // wait until queue is not empty
-    while (the_queue.empty()) {
-      // the_cond_var could wake up the thread spontaneously, even if the queue is still empty...
-      // so put this wakeup inside a while loop, such that the empty check is performed whenever it wakes up
-      the_cond_var.wait(lock); // release lock as long as the wait and reaquire it afterwards.
+    the_cond_var.wait(lock, [this] { return error || !the_queue.empty(); });
+
+    if (error) {
+      auto t = error;
+      error = t;
+      std::rethrow_exception(error);
     }
+
     auto v = the_queue.front();
     the_queue.pop();
     return v;
   }
 
+  void push_error(std::exception_ptr eptr) {
+    {
+      std::lock_guard<std::mutex> lock(the_mutex);
+      error = eptr;
+    }
+    the_cond_var.notify_one();
+  }
+
+  void cancel_read() { push_error(ReadCanceled{}); }
+
 private:
+  std::exception_ptr error;
   int32_t max_size;
   std::queue<T> the_queue;
   mutable std::mutex the_mutex;
   mutable std::condition_variable the_cond_var;
 };
 
-} // ns queue
-} // ns sweep
+} // namespace queue
+} // namespace sweep
 
 #endif

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -16,7 +16,7 @@ typedef struct sweep_error { std::string what; } sweep_error;
 
 typedef struct sweep_device {
   sweep::serial::device_s serial; // serial port communication
-  bool is_scanning;
+  std::atomic<bool> is_scanning;
   sweep::queue::queue<sweep_scan_s> scan_queue;
   std::atomic<bool> stop_thread;
 } sweep_device;
@@ -66,7 +66,7 @@ sweep_device_s sweep_device_construct(const char* port, int32_t bitrate, sweep_e
   sweep::serial::device_s serial = sweep::serial::device_construct(port, bitrate);
 
   // initialize assuming the device is scanning
-  auto out = new sweep_device{serial, /*is_scanning=*/true, /*scan_queue=*/{20}, /*stop_thread=*/{false}};
+  auto out = new sweep_device{serial, /*is_scanning=*/{true}, /*scan_queue=*/{20}, /*stop_thread=*/{false}};
 
   // send a stop scanning command in case the scanner was powered on and scanning
   sweep_device_stop_scanning(out, error);
@@ -183,9 +183,8 @@ sweep_scan_s sweep_device_get_scan(sweep_device_s device, sweep_error_s* error) 
   SWEEP_ASSERT(device);
   SWEEP_ASSERT(error);
   SWEEP_ASSERT(device->is_scanning);
-  (void)error;
 
-  auto out = device->scan_queue.dequeue();
+  auto out = device->scan_queue.pop();
   return out;
 } catch (const std::exception& e) {
   *error = sweep_error_construct(e.what());
@@ -225,7 +224,7 @@ void sweep_device_accumulate_scans(sweep_device_s device) try {
       }
 
       // place the scan in the queue
-      device->scan_queue.enqueue(out);
+      device->scan_queue.push(out);
 
       // place the sync reading at the start for the next scan
       responses[0] = responses[received - 1];
@@ -234,9 +233,9 @@ void sweep_device_accumulate_scans(sweep_device_s device) try {
       received = 1;
     }
   }
-} catch (const std::exception& e) {
-  // worker thread is dead at this point
-  (void)e;
+} catch (...) {
+  device->is_scanning = false;
+  device->scan_queue.push_error(std::current_exception());
 }
 
 bool sweep_device_get_motor_ready(sweep_device_s device, sweep_error_s* error) try {


### PR DESCRIPTION
#### Scope of changes
Forward errors from accumulate_scans to get_scan.

Also adds an additional function that allows to cancel a read from a different thread, but doesn't expose this in the API

#### Known Limitations
Doesn't address the more fundamental question, if an error inside  accumulate_scans should actually stop the worker thread and how the user is supposed to restart it.