### PR TITLE
Simplify azimuth conversion

### DIFF
--- a/libsweep/include/protocol.hpp
+++ b/libsweep/include/protocol.hpp
@@ -23,16 +23,16 @@ struct error : sweep::error::error {
 
 // Command Symbols
 
-constexpr uint8_t DATA_ACQUISITION_START[2] = { 'D', 'S' };
-constexpr uint8_t DATA_ACQUISITION_STOP[2] = { 'D', 'X' };
-constexpr uint8_t MOTOR_SPEED_ADJUST[2] = { 'M', 'S' };
-constexpr uint8_t MOTOR_READY[2] = { 'M', 'Z' };
-constexpr uint8_t MOTOR_INFORMATION[2] = { 'M', 'I' };
-constexpr uint8_t SAMPLE_RATE_ADJUST[2] = { 'L', 'R' };
-constexpr uint8_t SAMPLE_RATE_INFORMATION[2] = { 'L', 'I' };
-constexpr uint8_t VERSION_INFORMATION[2] = { 'I', 'V' };
-constexpr uint8_t DEVICE_INFORMATION[2] = { 'I', 'D' };
-constexpr uint8_t RESET_DEVICE[2] = { 'R', 'R' };
+constexpr uint8_t DATA_ACQUISITION_START[2] = {'D', 'S'};
+constexpr uint8_t DATA_ACQUISITION_STOP[2] = {'D', 'X'};
+constexpr uint8_t MOTOR_SPEED_ADJUST[2] = {'M', 'S'};
+constexpr uint8_t MOTOR_READY[2] = {'M', 'Z'};
+constexpr uint8_t MOTOR_INFORMATION[2] = {'M', 'I'};
+constexpr uint8_t SAMPLE_RATE_ADJUST[2] = {'L', 'R'};
+constexpr uint8_t SAMPLE_RATE_INFORMATION[2] = {'L', 'I'};
+constexpr uint8_t VERSION_INFORMATION[2] = {'I', 'V'};
+constexpr uint8_t DEVICE_INFORMATION[2] = {'I', 'D'};
+constexpr uint8_t RESET_DEVICE[2] = {'R', 'R'};
 
 // Packets for communication
 
@@ -82,9 +82,9 @@ struct response_param_s {
 
 static_assert(sizeof(response_param_s) == 9, "response param size mismatch");
 
-struct response_scan_packet_s{
+struct response_scan_packet_s {
   uint8_t sync_error; // see response_scan_packet_sync::bits below
-  uint16_t angle;     // see u16_to_f32
+  uint16_t angle;
   uint16_t distance;
   uint8_t signal_strength;
   uint8_t checksum;
@@ -183,9 +183,6 @@ void read_response_info_motor_ready(sweep::serial::device_s serial, const uint8_
 void read_response_info_motor_speed(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_motor_speed_s* info);
 
 void read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_sample_rate_s* info);
-
-// Some protocol conversion utilities
-inline float u16_to_f32(uint16_t v) { return ((float)(v >> 4u)) + (v & 15u) / 16.0f; }
 
 inline void integral_to_ascii_bytes(const int32_t integral, uint8_t bytes[2]) {
   SWEEP_ASSERT(integral >= 0);

--- a/libsweep/include/protocol.hpp
+++ b/libsweep/include/protocol.hpp
@@ -84,7 +84,7 @@ static_assert(sizeof(response_param_s) == 9, "response param size mismatch");
 
 struct response_scan_packet_s {
   uint8_t sync_error; // see response_scan_packet_sync::bits below
-  uint16_t angle;
+  uint16_t angle;     // see u16_to_f32
   uint16_t distance;
   uint8_t signal_strength;
   uint8_t checksum;
@@ -183,6 +183,9 @@ void read_response_info_motor_ready(sweep::serial::device_s serial, const uint8_
 void read_response_info_motor_speed(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_motor_speed_s* info);
 
 void read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_sample_rate_s* info);
+
+// Some protocol conversion utilities
+inline float u16_to_f32(uint16_t v) { return v / 16.0f; }
 
 inline void integral_to_ascii_bytes(const int32_t integral, uint8_t bytes[2]) {
   SWEEP_ASSERT(integral >= 0);

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -217,8 +217,8 @@ void sweep_device_accumulate_scans(sweep_device_s device) try {
       auto out = new sweep_scan;
       out->count = received - 1; // minus 1 to exclude sync reading
       for (int32_t it = 0; it < received - 1; ++it) {
-        // Convert angle from compact serial format to an integer representing milli-degrees.
-        out->angle[it] = static_cast<int32_t>(responses[it].angle / 16.f * 1000.f);
+        // Convert angle: compact serial format -> float (in degrees) -> int (in milli-degrees)
+        out->angle[it] = static_cast<int32_t>(sweep::protocol::u16_to_f32(responses[it].angle) * 1000.f);
         out->distance[it] = responses[it].distance;
         out->signal_strength[it] = responses[it].signal_strength;
       }
@@ -476,8 +476,8 @@ sweep_scan_s sweep_device_get_scan_direct(sweep_device_s device, sweep_error_s* 
   out->count = received;
 
   for (int32_t it = 0; it < received; ++it) {
-    // Convert angle from compact serial format to an integer representing milli-degrees.
-    out->angle[it] = static_cast<int32_t>(responses[it].angle / 16.f * 1000.f);
+    // Convert angle: compact serial format -> float (in degrees) -> int (in milli-degrees)
+    out->angle[it] = static_cast<int32_t>(sweep::protocol::u16_to_f32(responses[it].angle) * 1000.f);
     out->distance[it] = responses[it].distance;
     out->signal_strength[it] = responses[it].signal_strength;
   }

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -217,9 +217,8 @@ void sweep_device_accumulate_scans(sweep_device_s device) try {
       auto out = new sweep_scan;
       out->count = received - 1; // minus 1 to exclude sync reading
       for (int32_t it = 0; it < received - 1; ++it) {
-        // Convert angle from compact serial format to float (in degrees).
-        // In addition convert from degrees to milli-degrees.
-        out->angle[it] = static_cast<int32_t>(sweep::protocol::u16_to_f32(responses[it].angle) * 1000.f);
+        // Convert angle from compact serial format to an integer representing milli-degrees.
+        out->angle[it] = static_cast<int32_t>(responses[it].angle / 16.f * 1000.f);
         out->distance[it] = responses[it].distance;
         out->signal_strength[it] = responses[it].signal_strength;
       }
@@ -477,9 +476,8 @@ sweep_scan_s sweep_device_get_scan_direct(sweep_device_s device, sweep_error_s* 
   out->count = received;
 
   for (int32_t it = 0; it < received; ++it) {
-    // Convert angle from compact serial format to float (in degrees).
-    // In addition convert from degrees to milli-degrees.
-    out->angle[it] = static_cast<int32_t>(sweep::protocol::u16_to_f32(responses[it].angle) * 1000.f);
+    // Convert angle from compact serial format to an integer representing milli-degrees.
+    out->angle[it] = static_cast<int32_t>(responses[it].angle / 16.f * 1000.f);
     out->distance[it] = responses[it].distance;
     out->signal_strength[it] = responses[it].signal_strength;
   }


### PR DESCRIPTION
#### Scope of changes
Simplifies the conversion of the azimuth field. See #89 
Removes the overly complicated conversion method (`u16_to_f32`) from the protocol header, and updates the protocol docs.

#### Known Limitations 
Perhaps the docs should also include example conversions in languages other than js... as that really isn't the most likely use case. It was chosen as the example language more for simplicity and readability (almost like pseudo code).  But most users will likely be using c++ or something similar. 