### PR TITLE
Error propagation

### DIFF
--- a/libsweep/include/queue.hpp
+++ b/libsweep/include/queue.hpp
@@ -37,7 +37,7 @@ public:
     if (static_cast<int32_t>(the_queue.size()) >= max_size)
       the_queue.pop();
 
-    the_queue.push(v);
+    the_queue.push(std::move(v));
     the_cond_var.notify_one();
   }
 
@@ -50,7 +50,7 @@ public:
       // so put this wakeup inside a while loop, such that the empty check is performed whenever it wakes up
       the_cond_var.wait(lock); // release lock as long as the wait and reaquire it afterwards.
     }
-    auto v = the_queue.front();
+    auto v = std::move(the_queue.front());
     the_queue.pop();
     return v;
   }

--- a/libsweep/include/serial.hpp
+++ b/libsweep/include/serial.hpp
@@ -20,7 +20,7 @@ struct error : sweep::error::error {
   using base::base;
 };
 
-typedef struct device* device_s;
+using device_s = struct device* ;
 
 device_s device_construct(const char* port, int32_t bitrate);
 void device_destruct(device_s serial);

--- a/libsweep/src/dummy.cc
+++ b/libsweep/src/dummy.cc
@@ -7,19 +7,19 @@
 int32_t sweep_get_version(void) { return SWEEP_VERSION; }
 bool sweep_is_abi_compatible(void) { return sweep_get_version() >> 16u == SWEEP_VERSION_MAJOR; }
 
-typedef struct sweep_error { std::string what; } sweep_error;
+struct sweep_error { std::string what; };
 
-typedef struct sweep_device {
+struct sweep_device {
   bool is_scanning;
   int32_t motor_speed;
   int32_t sample_rate;
   int32_t nth_scan_request;
-} sweep_device;
+};
 
-typedef struct sweep_scan {
+struct sweep_scan {
   int32_t count;
   int32_t nth;
-} sweep_scan;
+};
 
 const char* sweep_error_message(sweep_error_s error) {
   SWEEP_ASSERT(error);

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -12,23 +12,23 @@
 int32_t sweep_get_version(void) { return SWEEP_VERSION; }
 bool sweep_is_abi_compatible(void) { return sweep_get_version() >> 16u == SWEEP_VERSION_MAJOR; }
 
-typedef struct sweep_error { std::string what; } sweep_error;
+struct sweep_error { std::string what; };
 
-typedef struct sweep_device {
+struct sweep_device {
   sweep::serial::device_s serial; // serial port communication
   bool is_scanning;
   sweep::queue::queue<sweep_scan_s> scan_queue;
   std::atomic<bool> stop_thread;
-} sweep_device;
+} ;
 
 #define SWEEP_MAX_SAMPLES 4096
 
-typedef struct sweep_scan {
+struct sweep_scan {
   int32_t angle[SWEEP_MAX_SAMPLES];           // in millidegrees
   int32_t distance[SWEEP_MAX_SAMPLES];        // in cm
   int32_t signal_strength[SWEEP_MAX_SAMPLES]; // range 0:255
   int32_t count;
-} sweep_scan;
+};
 
 // Constructor hidden from users
 static sweep_error_s sweep_error_construct(const char* what) {

--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -16,7 +16,7 @@
 namespace sweep {
 namespace serial {
 
-typedef struct device { int32_t fd; } device;
+struct device { int32_t fd; };
 
 static speed_t get_baud(int32_t bitrate) {
   SWEEP_ASSERT(bitrate > 0);

--- a/libsweep/src/win/serial.cc
+++ b/libsweep/src/win/serial.cc
@@ -11,12 +11,12 @@
 namespace sweep {
 namespace serial {
 
-typedef struct device {
+struct device {
   HANDLE h_comm;
   OVERLAPPED os_reader;
   bool waiting_on_read;      // Used to prevent creation of new read operation if one is outstanding
   DWORD read_timeout_millis; // timeout interval for entire read operation
-} device;
+};
 
 static int32_t detail_get_port_number(const char* port) {
   SWEEP_ASSERT(port);


### PR DESCRIPTION
### Not yet tested! (RFC)
### Scope of changes
<!-- 
Describe the scope of any changes made. 
What does the Pull Request accomplish? 
Summarize what parts of the code were modified to implement the change.
-->
Propagates exceptions occuring in the worker thread to `sweep_device_get_scan`.

- Modifies queue code to play nice with move-only types
- Manages dynamically allocated memory via unqiue_ptr as long as possible to prevent any memory leaks
- Combines pointer to scan and exception pointer (one of them being nullptr) into one struct and passes them through the queue
- Removes some redundant type defs accross the code base for consistency reasons (ccan drop that commit from the PR if prefered)

### Known Limitations
<!-- 
Describe any known limitations.
If the change does not yet support a certain feature of the library, or a particular language binding, note that here.
-->
- Not yet tested (seeking early feedback)
- Actual error handling (instead of just reporting) might be desired (see https://github.com/scanse/sweep-sdk/issues/91)


<!--
Thanks again for submitting a Pull Request. 
We value community contribution and will work hard to integrate your changes as quickly as possible.
-->