### PR TITLE
Adds release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+
+## v1.1.1
+
+This release is compatible with device firmware v1.2.
+
+Changes:
+- libsweep: Adapts motor calibration timeout to firmware changes
+
+
+## v1.1.0
+
+This release is compatible with device firmware v1.1.
+
+Changes:
+- libsweep: Adaptes protocol implementation to firmware changes
+- libsweep: Accumulates scans in a background worker thread
+
+
+## v0.1.0
+
+This is the initial release v0.1.0 and is compatible with the Sweep device firmware version v1.0.
+
+It comes with C99, C++11, Python2 / Python3, and Node.js bindings.
+
+Some examples we include:
+
+    Real-time point cloud viewer
+    Pub-Sub networking example
+    Websocket daemon for device
+
+Happy scanning!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+# Publishing a new version
+
+- [ ] Sync. `CHANGELOG.md` with latest changes and fixes
+- [ ] Sync. version number in `libsweep/CMakeLists.txt`, `sweeppy/setup.py`, `sweepjs/package.json`
+- [ ] Make sure Travis and AppVeyor are green and show no warnings
+- [ ] Continuous Integration only tests dummy library: test with real device
+- [ ] Tag a commit `git tag -a vx.y.z gitsha` (we use [semantic versioning](http://semver.org/))
+- [ ] Push tag to Github `git push origin vx.y.z`
+- [ ] Head over to https://github.com/scanse/sweep-sdk/releases and make a release


### PR DESCRIPTION
Documenting the release process.

I also like to keep a copy of the changelog in the repo. and not only [on Github](https://github.com/scanse/sweep-sdk/releases).