### PR TITLE
Hides impl. details from API surface

### DIFF
--- a/libsweep/README.md
+++ b/libsweep/README.md
@@ -341,6 +341,7 @@ Will only succeed if the device is ready. A device is only ready if the motor sp
 Proper use involves checking that the motor speed has stabilized (using `sweep_device_get_motor_ready`) before attempting to adjust the motor speed to a new value.
 In case of error a `sweep_error_s` will be written into `error`. This method will error on legitimate failures (ex: the motor speed has not yet stabilized).
 -->
+
 ### License
 
 Copyright © 2016 Daniel J. Hofmann

--- a/libsweep/README.md
+++ b/libsweep/README.md
@@ -307,41 +307,6 @@ int32_t sweep_scan_get_signal_strength(sweep_scan_s scan, int32_t sample)
 
 Returns the signal strength (0 low -- 255 high) for the `sample`th sample in the `sweep_scan_s`.
 
-<!--
-#### Alternative direct functions
-Many of the SDK methods block for various reasons, such as waiting for a data stream to terminate, waiting for the device to finish calibrating, or waiting for the motor speed to stabilize. This can be an issue for low-level applications where blocking isn't ideal. The following methods (mostly non-blocking) are provided as a workaround. Care must be taken when using these methods as they can error on valid failures if the state of the device is not checked before hand.
-
-```c++
-void sweep_device_attempt_start_scanning(sweep_device_s device, sweep_error_s* error)
-```
-
-Non-blocking alternative to `sweep_device_start_scanning`. 
-Signals the `sweep_device_s` to start scanning. 
-Will only succeed if the motor speed is \>0Hz and stable.
-User is responsible for checking these conditions before calling. User can check that motor speed has stabilized using `sweep_device_get_motor_ready` and that motor speed is \> 0Hz using `sweep_device_get_speed`.
-Will NOT start an internal background thread. User is responsible for keeping up with incoming scans by calling `sweep_device_get_scan_direct`.
-In case of error a `sweep_error_s` will be written into `error`. This method will error on legitimate failures (ex: the motor speed is stationary or has not yet stabilized).
-
-
-```c++
-sweep_scan_s sweep_device_get_scan_direct(sweep_device_s device, sweep_error_s* error)
-```
-
-Returns the ordered readings from the 2nd reading of the current scan through the 1st reading of the subsequent scan.
-Blocks waiting for the `sweep_device_s` to accumulate a full 360 degree scan into `sweep_scan_s`. To be used after calling `sweep_device_attempt_start_scanning`, NOT after `sweep_device_start_scanning`.
-In case of error a `sweep_error_s` will be written into `error`.
-
-```c++
-void sweep_device_attempt_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error_s* error)
-```
-
-Non-blocking alternative to `sweep_device_set_motor_speed`.
-Sets the `sweep_device_s`'s motor speed in Hz.
-Will only succeed if the device is ready. A device is only ready if the motor speed has stabilized to the current setting and the calibration routine is complete.
-Proper use involves checking that the motor speed has stabilized (using `sweep_device_get_motor_ready`) before attempting to adjust the motor speed to a new value.
-In case of error a `sweep_error_s` will be written into `error`. This method will error on legitimate failures (ex: the motor speed has not yet stabilized).
--->
-
 ### License
 
 Copyright © 2016 Daniel J. Hofmann

--- a/libsweep/include/sweep/sweep.h
+++ b/libsweep/include/sweep/sweep.h
@@ -57,13 +57,8 @@ SWEEP_API void sweep_device_start_scanning(sweep_device_s device, sweep_error_s*
 // Stops stream, blocks while leftover stream is flushed, and sends stop once more to validate response
 SWEEP_API void sweep_device_stop_scanning(sweep_device_s device, sweep_error_s* error);
 
-// Blocks until the device is ready (calibration complete and motor speed stabilized)
-void sweep_device_wait_until_motor_ready(sweep_device_s device, sweep_error_s* error);
-
 // Retrieves a scan from the queue (will block until scan is available)
 SWEEP_API sweep_scan_s sweep_device_get_scan(sweep_device_s device, sweep_error_s* error);
-// Accumulates scans in the queue  (method to be used by background thread)
-void sweep_device_accumulate_scans(sweep_device_s device);
 
 SWEEP_API bool sweep_device_get_motor_ready(sweep_device_s device, sweep_error_s* error);
 SWEEP_API int32_t sweep_device_get_motor_speed(sweep_device_s device, sweep_error_s* error);
@@ -81,15 +76,6 @@ SWEEP_API int32_t sweep_scan_get_signal_strength(sweep_scan_s scan, int32_t samp
 SWEEP_API void sweep_scan_destruct(sweep_scan_s scan);
 
 SWEEP_API void sweep_device_reset(sweep_device_s device, sweep_error_s* error);
-
-//------- Alternative methods for Low Level development (can error on failure) ------ //
-// Not yet part of the public API
-// Attempts to start scanning without waiting for motor ready, does NOT start background thread to accumulate scans
-void sweep_device_attempt_start_scanning(sweep_device_s device, sweep_error_s* error);
-// Read incoming scan directly (not retrieving from the queue)
-sweep_scan_s sweep_device_get_scan_direct(sweep_device_s device, sweep_error_s* error);
-// Attempts to set motor speed without waiting for motor ready
-void sweep_device_attempt_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error_s* error);
 
 #ifdef __cplusplus
 }

--- a/libsweep/src/dummy.cc
+++ b/libsweep/src/dummy.cc
@@ -33,6 +33,37 @@ void sweep_error_destruct(sweep_error_s error) {
   delete error;
 }
 
+static void sweep_device_wait_until_motor_ready(sweep_device_s device, sweep_error_s* error) {
+  SWEEP_ASSERT(device);
+  SWEEP_ASSERT(error);
+  SWEEP_ASSERT(!device->is_scanning);
+
+  (void)device;
+  (void)error;
+}
+
+static void sweep_device_attempt_start_scanning(sweep_device_s device, sweep_error_s* error) {
+  SWEEP_ASSERT(device);
+  SWEEP_ASSERT(error);
+  SWEEP_ASSERT(!device->is_scanning);
+  (void)error;
+
+  if (device->is_scanning)
+    return;
+
+  device->is_scanning = true;
+}
+
+static void sweep_device_attempt_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error_s* error) {
+  SWEEP_ASSERT(device);
+  SWEEP_ASSERT(hz >= 0 && hz <= 10);
+  SWEEP_ASSERT(error);
+  SWEEP_ASSERT(!device->is_scanning);
+  (void)error;
+
+  device->motor_speed = hz;
+}
+
 sweep_device_s sweep_device_construct_simple(const char* port, sweep_error_s* error) {
   SWEEP_ASSERT(error);
 
@@ -75,15 +106,6 @@ void sweep_device_stop_scanning(sweep_device_s device, sweep_error_s* error) {
   (void)error;
 
   device->is_scanning = false;
-}
-
-void sweep_device_wait_until_motor_ready(sweep_device_s device, sweep_error_s* error) {
-  SWEEP_ASSERT(device);
-  SWEEP_ASSERT(error);
-  SWEEP_ASSERT(!device->is_scanning);
-
-  (void)device;
-  (void)error;
 }
 
 sweep_scan_s sweep_device_get_scan(sweep_device_s device, sweep_error_s* error) {
@@ -212,42 +234,4 @@ void sweep_device_reset(sweep_device_s device, sweep_error_s* error) {
   SWEEP_ASSERT(!device->is_scanning);
   (void)device;
   (void)error;
-}
-
-void sweep_device_attempt_start_scanning(sweep_device_s device, sweep_error_s* error) {
-  SWEEP_ASSERT(device);
-  SWEEP_ASSERT(error);
-  SWEEP_ASSERT(!device->is_scanning);
-  (void)error;
-
-  if (device->is_scanning)
-    return;
-
-  device->is_scanning = true;
-}
-
-sweep_scan_s sweep_device_get_scan_direct(sweep_device_s device, sweep_error_s* error) {
-  SWEEP_ASSERT(device);
-  SWEEP_ASSERT(error);
-  SWEEP_ASSERT(device->is_scanning);
-  (void)error;
-
-  auto out = new sweep_scan{/*count=*/device->is_scanning ? 16 : 0, /*nth=*/device->nth_scan_request};
-
-  device->nth_scan_request += 1;
-
-  // Artificially introduce slowdown, to simulate device rotation
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-  return out;
-}
-
-void sweep_device_attempt_set_motor_speed(sweep_device_s device, int32_t hz, sweep_error_s* error) {
-  SWEEP_ASSERT(device);
-  SWEEP_ASSERT(hz >= 0 && hz <= 10);
-  SWEEP_ASSERT(error);
-  SWEEP_ASSERT(!device->is_scanning);
-  (void)error;
-
-  device->motor_speed = hz;
 }


### PR DESCRIPTION
Features not exposed via `SWEEP_API` must not be exposed in the interface header.
This changeset moves some code around to cleanup the API surface.