### PR TITLE
Unplug exception

### DIFF
--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -339,7 +339,6 @@ void device_read(device_s serial, void* to, int32_t len) {
           throw error{"reading from serial device failed"};
         }
       } else if(ret == 0){
-        perror("encountered EOF on serial device");
         throw error{"encountered EOF on serial device"};
       } else {
         bytes_read += ret;

--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -254,21 +254,17 @@ device_s device_construct(const char* port, int32_t bitrate) {
 
   int32_t fd = open(port, O_RDWR | O_NOCTTY | O_NONBLOCK);
 
-  printf("device_construct - 1\n");
   if (fd == -1)
     throw error{"opening serial port failed"};
 
-  printf("device_construct - 2\n");
   if (!isatty(fd))
     throw error{"serial port is not a TTY"};
 
   struct termios options;
 
-  printf("device_construct - 3\n");
   if (tcgetattr(fd, &options) == -1)
     throw error{"querying terminal options failed"};
 
-  printf("device_construct - 4\n");
   // Input Flags
   options.c_iflag &= ~(INLCR | IGNCR | ICRNL | IGNBRK);
 
@@ -293,12 +289,10 @@ device_s device_construct(const char* port, int32_t bitrate) {
   cfsetispeed(&options, baud);
   cfsetospeed(&options, baud);
 
-  printf("device_construct - 5\n");
   // flush the port
   if (tcflush(fd, TCIFLUSH) == -1)
     throw error{"flushing the serial port failed"};
 
-printf("device_construct - 6\n");
   // set port attributes
   if (tcsetattr(fd, TCSANOW, &options) == -1) {
     if (close(fd) == -1)
@@ -307,7 +301,6 @@ printf("device_construct - 6\n");
     throw error{"setting terminal options failed"};
   }
 
-printf("device_construct - 7\n");
   auto out = new device{fd};
   return out;
 }
@@ -369,7 +362,7 @@ void device_write(device_s serial, const void* from, int32_t len) {
     int32_t ret = write(serial->fd, (const char*)from + bytes_written, len - bytes_written);
 
     if (ret == -1) {
-      if (/*errno == EAGAIN || */errno == EINTR) {
+      if (errno == EAGAIN || errno == EINTR) {
         continue;
       } else {
         throw error{"writing to serial device failed"};


### PR DESCRIPTION
#### Issues

When the cable becomes unplugged the device_read function goes into an infinite loop causing the caller to hang and the process to consume 100% CPU cycles. This failure mode can be more gracefully handled by detecting EOF.

* https://github.com/scanse/sweep-ros/issues/11
* https://github.com/scanse/sweep-sdk/issues/102

#### Scope of changes

Modified Linux serial support to throw an exception if an EOF condition is detected.

#### Known Limitations

The error handling facilities are not very graceful and if the caller does not handle the exception, it result in a crash in upstream programs which may not have previously been expected(but neither was a hang). I have not yet been able to fully recover the connection after handling the exception but now you atleast get a clear error message.
