### PR TITLE
Refactor some libsweep internals

### DIFF
--- a/libsweep/include/protocol.hpp
+++ b/libsweep/include/protocol.hpp
@@ -88,24 +88,31 @@ struct response_scan_packet_s {
   uint16_t distance;
   uint8_t signal_strength;
   uint8_t checksum;
+
+  struct sync_error_bits {
+    enum bits : uint8_t {
+      sync = 1 << 0,                // beginning of new full scan
+      communication_error = 1 << 1, // communication error
+
+      // Reserved for future error bits
+      reserved2 = 1 << 2,
+      reserved3 = 1 << 3,
+      reserved4 = 1 << 4,
+      reserved5 = 1 << 5,
+      reserved6 = 1 << 6,
+      reserved7 = 1 << 7,
+    };
+  };
+
+  bool is_sync() const { return sync_error & sync_error_bits::sync; }
+  bool has_error() const { return sync_error >> 1 != 0; } // shift out sync bit, others are errors
+  int get_angle_millideg() const {
+    // angle is transmitted as fixed point integer with scaling factor of 16
+    return static_cast<int>(angle * 1000 / 16.0f);
+  }
 };
 
 static_assert(sizeof(response_scan_packet_s) == 7, "response scan packet size mismatch");
-
-namespace response_scan_packet_sync {
-enum bits : uint8_t {
-  sync = 1 << 0,                // beginning of new full scan
-  communication_error = 1 << 1, // communication error
-
-  // Reserved for future error bits
-  reserved2 = 1 << 2,
-  reserved3 = 1 << 3,
-  reserved4 = 1 << 4,
-  reserved5 = 1 << 5,
-  reserved6 = 1 << 6,
-  reserved7 = 1 << 7,
-};
-}
 
 struct response_info_device_s {
   uint8_t cmdByte1;
@@ -183,12 +190,6 @@ void read_response_info_motor_ready(sweep::serial::device_s serial, const uint8_
 void read_response_info_motor_speed(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_motor_speed_s* info);
 
 void read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_sample_rate_s* info);
-
-// Some protocol conversion utilities
-inline int angle_raw_to_millideg(uint16_t v) {
-  // angle is transmitted as fixed point integer with scaling factor of 16
-  return static_cast<int>(v * 1000 / 16.0f);
-}
 
 inline void integral_to_ascii_bytes(const int32_t integral, uint8_t bytes[2]) {
   SWEEP_ASSERT(integral >= 0);

--- a/libsweep/include/protocol.hpp
+++ b/libsweep/include/protocol.hpp
@@ -179,17 +179,17 @@ void write_command(sweep::serial::device_s serial, const uint8_t cmd[2]);
 
 void write_command_with_arguments(sweep::serial::device_s serial, const uint8_t cmd[2], const uint8_t arg[2]);
 
-void read_response_header(sweep::serial::device_s serial, const uint8_t cmd[2], response_header_s* header);
+response_header_s read_response_header(sweep::serial::device_s serial, const uint8_t cmd[2]);
 
-void read_response_param(sweep::serial::device_s serial, const uint8_t cmd[2], response_param_s* param);
+response_param_s read_response_param(sweep::serial::device_s serial, const uint8_t cmd[2]);
 
-void read_response_scan(sweep::serial::device_s serial, response_scan_packet_s* scan);
+response_scan_packet_s read_response_scan(sweep::serial::device_s serial);
 
-void read_response_info_motor_ready(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_motor_ready_s* info);
+response_info_motor_ready_s read_response_info_motor_ready(sweep::serial::device_s serial, const uint8_t cmd[2]);
 
-void read_response_info_motor_speed(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_motor_speed_s* info);
+response_info_motor_speed_s read_response_info_motor_speed(sweep::serial::device_s serial, const uint8_t cmd[2]);
 
-void read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_sample_rate_s* info);
+response_info_sample_rate_s read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2]);
 
 inline void integral_to_ascii_bytes(const int32_t integral, uint8_t bytes[2]) {
   SWEEP_ASSERT(integral >= 0);

--- a/libsweep/include/protocol.hpp
+++ b/libsweep/include/protocol.hpp
@@ -185,11 +185,11 @@ response_param_s read_response_param(sweep::serial::device_s serial, const uint8
 
 response_scan_packet_s read_response_scan(sweep::serial::device_s serial);
 
-response_info_motor_ready_s read_response_info_motor_ready(sweep::serial::device_s serial, const uint8_t cmd[2]);
+response_info_motor_ready_s read_response_info_motor_ready(sweep::serial::device_s serial);
 
-response_info_motor_speed_s read_response_info_motor_speed(sweep::serial::device_s serial, const uint8_t cmd[2]);
+response_info_motor_speed_s read_response_info_motor_speed(sweep::serial::device_s serial);
 
-response_info_sample_rate_s read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2]);
+response_info_sample_rate_s read_response_info_sample_rate(sweep::serial::device_s serial);
 
 inline void integral_to_ascii_bytes(const int32_t integral, uint8_t bytes[2]) {
   SWEEP_ASSERT(integral >= 0);

--- a/libsweep/src/protocol.cc
+++ b/libsweep/src/protocol.cc
@@ -109,14 +109,13 @@ response_scan_packet_s read_response_scan(serial::device_s serial) {
   return scan;
 }
 
-response_info_motor_ready_s read_response_info_motor_ready(serial::device_s serial, const uint8_t cmd[2]) {
+response_info_motor_ready_s read_response_info_motor_ready(serial::device_s serial) {
   SWEEP_ASSERT(serial);
-  SWEEP_ASSERT(cmd);
 
   response_info_motor_ready_s info;
   serial::device_read(serial, &info, sizeof(info));
 
-  bool ok = info.cmdByte1 == cmd[0] && info.cmdByte2 == cmd[1];
+  bool ok = info.cmdByte1 == MOTOR_READY[0] && info.cmdByte2 == MOTOR_READY[1];
 
   if (!ok)
     throw error{"invalid motor ready response commands"};
@@ -124,14 +123,13 @@ response_info_motor_ready_s read_response_info_motor_ready(serial::device_s seri
   return info;
 }
 
-response_info_motor_speed_s read_response_info_motor_speed(serial::device_s serial, const uint8_t cmd[2]) {
+response_info_motor_speed_s read_response_info_motor_speed(serial::device_s serial) {
   SWEEP_ASSERT(serial);
-  SWEEP_ASSERT(cmd);
 
   response_info_motor_speed_s info;
   serial::device_read(serial, &info, sizeof(info));
 
-  bool ok = info.cmdByte1 == cmd[0] && info.cmdByte2 == cmd[1];
+  bool ok = info.cmdByte1 == MOTOR_INFORMATION[0] && info.cmdByte2 == MOTOR_INFORMATION[1];
 
   if (!ok)
     throw error{"invalid motor info response commands"};
@@ -139,14 +137,13 @@ response_info_motor_speed_s read_response_info_motor_speed(serial::device_s seri
   return info;
 }
 
-response_info_sample_rate_s read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2]) {
+response_info_sample_rate_s read_response_info_sample_rate(sweep::serial::device_s serial) {
   SWEEP_ASSERT(serial);
-  SWEEP_ASSERT(cmd);
 
   response_info_sample_rate_s info;
   serial::device_read(serial, &info, sizeof(info));
 
-  bool ok = info.cmdByte1 == cmd[0] && info.cmdByte2 == cmd[1];
+  bool ok = info.cmdByte1 == SAMPLE_RATE_INFORMATION[0] && info.cmdByte2 == SAMPLE_RATE_INFORMATION[1];
 
   if (!ok)
     throw error{"invalid sample rate info response commands"};

--- a/libsweep/src/protocol.cc
+++ b/libsweep/src/protocol.cc
@@ -55,91 +55,103 @@ void write_command_with_arguments(serial::device_s serial, const uint8_t cmd[2],
   serial::device_write(serial, &packet, sizeof(cmd_param_packet_s));
 }
 
-void read_response_header(serial::device_s serial, const uint8_t cmd[2], response_header_s* header) {
+response_header_s read_response_header(serial::device_s serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(serial);
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(header);
 
-  serial::device_read(serial, header, sizeof(response_header_s));
+  response_header_s header;
+  serial::device_read(serial, &header, sizeof(header));
 
-  uint8_t checksum = checksum_response_header(*header);
+  uint8_t checksum = checksum_response_header(header);
 
-  if (checksum != header->cmdSum)
+  if (checksum != header.cmdSum)
     throw error{"invalid response header checksum"};
 
-  bool ok = header->cmdByte1 == cmd[0] && header->cmdByte2 == cmd[1];
+  bool ok = header.cmdByte1 == cmd[0] && header.cmdByte2 == cmd[1];
 
   if (!ok)
     throw error{"invalid header response commands"};
+
+  return header;
 }
 
-void read_response_param(serial::device_s serial, const uint8_t cmd[2], response_param_s* param) {
+response_param_s read_response_param(serial::device_s serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(serial);
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(param);
 
-  serial::device_read(serial, param, sizeof(response_param_s));
+  response_param_s param;
+  serial::device_read(serial, &param, sizeof(param));
 
-  uint8_t checksum = checksum_response_param(*param);
+  uint8_t checksum = checksum_response_param(param);
 
-  if (checksum != param->cmdSum)
+  if (checksum != param.cmdSum)
     throw error{"invalid response param header checksum"};
 
-  bool ok = param->cmdByte1 == cmd[0] && param->cmdByte2 == cmd[1];
+  bool ok = param.cmdByte1 == cmd[0] && param.cmdByte2 == cmd[1];
 
   if (!ok)
     throw error{"invalid param response commands"};
+
+  return param;
 }
 
-void read_response_scan(serial::device_s serial, response_scan_packet_s* scan) {
+response_scan_packet_s read_response_scan(serial::device_s serial) {
   SWEEP_ASSERT(serial);
-  SWEEP_ASSERT(scan);
 
-  serial::device_read(serial, scan, sizeof(response_scan_packet_s));
+  response_scan_packet_s scan;
+  serial::device_read(serial, &scan, sizeof(scan));
 
-  uint8_t checksum = checksum_response_scan_packet(*scan);
+  uint8_t checksum = checksum_response_scan_packet(scan);
 
-  if (checksum != scan->checksum)
+  if (checksum != scan.checksum)
     throw error{"invalid scan response commands"};
+
+  return scan;
 }
 
-void read_response_info_motor_ready(serial::device_s serial, const uint8_t cmd[2], response_info_motor_ready_s* info) {
+response_info_motor_ready_s read_response_info_motor_ready(serial::device_s serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(serial);
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(info);
 
-  serial::device_read(serial, info, sizeof(response_info_motor_ready_s));
+  response_info_motor_ready_s info;
+  serial::device_read(serial, &info, sizeof(info));
 
-  bool ok = info->cmdByte1 == cmd[0] && info->cmdByte2 == cmd[1];
+  bool ok = info.cmdByte1 == cmd[0] && info.cmdByte2 == cmd[1];
 
   if (!ok)
     throw error{"invalid motor ready response commands"};
+
+  return info;
 }
 
-void read_response_info_motor_speed(serial::device_s serial, const uint8_t cmd[2], response_info_motor_speed_s* info) {
+response_info_motor_speed_s read_response_info_motor_speed(serial::device_s serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(serial);
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(info);
 
-  serial::device_read(serial, info, sizeof(response_info_motor_speed_s));
+  response_info_motor_speed_s info;
+  serial::device_read(serial, &info, sizeof(info));
 
-  bool ok = info->cmdByte1 == cmd[0] && info->cmdByte2 == cmd[1];
+  bool ok = info.cmdByte1 == cmd[0] && info.cmdByte2 == cmd[1];
 
   if (!ok)
     throw error{"invalid motor info response commands"};
+
+  return info;
 }
 
-void read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2], response_info_sample_rate_s* info) {
+response_info_sample_rate_s read_response_info_sample_rate(sweep::serial::device_s serial, const uint8_t cmd[2]) {
   SWEEP_ASSERT(serial);
   SWEEP_ASSERT(cmd);
-  SWEEP_ASSERT(info);
 
-  serial::device_read(serial, info, sizeof(response_info_sample_rate_s));
+  response_info_sample_rate_s info;
+  serial::device_read(serial, &info, sizeof(info));
 
-  bool ok = info->cmdByte1 == cmd[0] && info->cmdByte2 == cmd[1];
+  bool ok = info.cmdByte1 == cmd[0] && info.cmdByte2 == cmd[1];
 
   if (!ok)
     throw error{"invalid sample rate info response commands"};
+
+  return info;
 }
 
 } // ns protocol

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -106,8 +106,7 @@ static void sweep_device_accumulate_scans(sweep_device_s device) try {
 
   while (!device->stop_thread && received < SWEEP_MAX_SAMPLES) {
 
-    sweep::protocol::response_scan_packet_s response;
-    sweep::protocol::read_response_scan(device->serial, &response);
+    const auto response = sweep::protocol::read_response_scan(device->serial);
 
     if (!response.has_error()) {
       buffer[received] = parse_payload(response);
@@ -149,8 +148,7 @@ static void sweep_device_attempt_start_scanning(sweep_device_s device, sweep_err
 
   sweep::protocol::write_command(device->serial, sweep::protocol::DATA_ACQUISITION_START);
 
-  sweep::protocol::response_header_s response;
-  sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_START, &response);
+  auto response = sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_START);
 
   // Check the status bytes do not indicate failure
   const uint8_t status_bytes[2] = {response.cmdStatusByte1, response.cmdStatusByte2};
@@ -181,8 +179,7 @@ static void sweep_device_attempt_set_motor_speed(sweep_device_s device, int32_t 
 
   sweep::protocol::write_command_with_arguments(device->serial, sweep::protocol::MOTOR_SPEED_ADJUST, args);
 
-  sweep::protocol::response_param_s response;
-  sweep::protocol::read_response_param(device->serial, sweep::protocol::MOTOR_SPEED_ADJUST, &response);
+  const auto response = sweep::protocol::read_response_param(device->serial, sweep::protocol::MOTOR_SPEED_ADJUST);
 
   // Check the status bytes do not indicate failure
   const uint8_t status_bytes[2] = {response.cmdStatusByte1, response.cmdStatusByte2};
@@ -297,9 +294,8 @@ void sweep_device_stop_scanning(sweep_device_s device, sweep_error_s* error) try
   // Read the response from the first stop command
   // It is possible this will contain garbage bytes (leftover from data stream), and will error
   // But we are guaranteed to read at least as many bytes as the length of a stop response
-  sweep::protocol::response_header_s garbage_response;
   try {
-    sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_STOP, &garbage_response);
+    sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_STOP);
   } catch (const std::exception& ignore) {
     // Catch and ignore the error in the case of the stop response containing garbage bytes
     // Occurs if the device was actively streaming data before the stop cmd
@@ -313,8 +309,7 @@ void sweep_device_stop_scanning(sweep_device_s device, sweep_error_s* error) try
   sweep::protocol::write_command(device->serial, sweep::protocol::DATA_ACQUISITION_STOP);
 
   // read the response
-  sweep::protocol::response_header_s response;
-  sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_STOP, &response);
+  sweep::protocol::read_response_header(device->serial, sweep::protocol::DATA_ACQUISITION_STOP);
 
   device->is_scanning = false;
 } catch (const std::exception& e) {
@@ -347,8 +342,7 @@ bool sweep_device_get_motor_ready(sweep_device_s device, sweep_error_s* error) t
 
   sweep::protocol::write_command(device->serial, sweep::protocol::MOTOR_READY);
 
-  sweep::protocol::response_info_motor_ready_s response;
-  sweep::protocol::read_response_info_motor_ready(device->serial, sweep::protocol::MOTOR_READY, &response);
+  const auto response = sweep::protocol::read_response_info_motor_ready(device->serial, sweep::protocol::MOTOR_READY);
 
   int32_t ready_code = sweep::protocol::ascii_bytes_to_integral(response.motor_ready);
   SWEEP_ASSERT(ready_code >= 0);
@@ -366,8 +360,7 @@ int32_t sweep_device_get_motor_speed(sweep_device_s device, sweep_error_s* error
 
   sweep::protocol::write_command(device->serial, sweep::protocol::MOTOR_INFORMATION);
 
-  sweep::protocol::response_info_motor_speed_s response;
-  sweep::protocol::read_response_info_motor_speed(device->serial, sweep::protocol::MOTOR_INFORMATION, &response);
+  const auto response = sweep::protocol::read_response_info_motor_speed(device->serial, sweep::protocol::MOTOR_INFORMATION);
 
   int32_t speed = sweep::protocol::ascii_bytes_to_integral(response.motor_speed);
   SWEEP_ASSERT(speed >= 0);
@@ -400,8 +393,7 @@ int32_t sweep_device_get_sample_rate(sweep_device_s device, sweep_error_s* error
 
   sweep::protocol::write_command(device->serial, sweep::protocol::SAMPLE_RATE_INFORMATION);
 
-  sweep::protocol::response_info_sample_rate_s response;
-  sweep::protocol::read_response_info_sample_rate(device->serial, sweep::protocol::SAMPLE_RATE_INFORMATION, &response);
+  const auto response = sweep::protocol::read_response_info_sample_rate(device->serial, sweep::protocol::SAMPLE_RATE_INFORMATION);
 
   // 01: 500-600Hz, 02: 750-800Hz, 03: 1000-1050Hz
   int32_t code = sweep::protocol::ascii_bytes_to_integral(response.sample_rate);
@@ -455,8 +447,7 @@ void sweep_device_set_sample_rate(sweep_device_s device, int32_t hz, sweep_error
 
   sweep::protocol::write_command_with_arguments(device->serial, sweep::protocol::SAMPLE_RATE_ADJUST, args);
 
-  sweep::protocol::response_param_s response;
-  sweep::protocol::read_response_param(device->serial, sweep::protocol::SAMPLE_RATE_ADJUST, &response);
+  const auto response = sweep::protocol::read_response_param(device->serial, sweep::protocol::SAMPLE_RATE_ADJUST);
 
   // Check the status bytes do not indicate failure
   const uint8_t status_bytes[2] = {response.cmdStatusByte1, response.cmdStatusByte2};

--- a/libsweep/src/sweep.cc
+++ b/libsweep/src/sweep.cc
@@ -342,7 +342,7 @@ bool sweep_device_get_motor_ready(sweep_device_s device, sweep_error_s* error) t
 
   sweep::protocol::write_command(device->serial, sweep::protocol::MOTOR_READY);
 
-  const auto response = sweep::protocol::read_response_info_motor_ready(device->serial, sweep::protocol::MOTOR_READY);
+  const auto response = sweep::protocol::read_response_info_motor_ready(device->serial);
 
   int32_t ready_code = sweep::protocol::ascii_bytes_to_integral(response.motor_ready);
   SWEEP_ASSERT(ready_code >= 0);
@@ -360,7 +360,7 @@ int32_t sweep_device_get_motor_speed(sweep_device_s device, sweep_error_s* error
 
   sweep::protocol::write_command(device->serial, sweep::protocol::MOTOR_INFORMATION);
 
-  const auto response = sweep::protocol::read_response_info_motor_speed(device->serial, sweep::protocol::MOTOR_INFORMATION);
+  const auto response = sweep::protocol::read_response_info_motor_speed(device->serial);
 
   int32_t speed = sweep::protocol::ascii_bytes_to_integral(response.motor_speed);
   SWEEP_ASSERT(speed >= 0);
@@ -393,7 +393,7 @@ int32_t sweep_device_get_sample_rate(sweep_device_s device, sweep_error_s* error
 
   sweep::protocol::write_command(device->serial, sweep::protocol::SAMPLE_RATE_INFORMATION);
 
-  const auto response = sweep::protocol::read_response_info_sample_rate(device->serial, sweep::protocol::SAMPLE_RATE_INFORMATION);
+  const auto response = sweep::protocol::read_response_info_sample_rate(device->serial);
 
   // 01: 500-600Hz, 02: 750-800Hz, 03: 1000-1050Hz
   int32_t code = sweep::protocol::ascii_bytes_to_integral(response.sample_rate);


### PR DESCRIPTION
This is a collection of refactorings concerning the protocol functions and the `sweep_device_accumulate_scans` function. The reason those are in one PR is that they partially depend on each other.

The PRs has two main goals:
- Pushing more code that is concerned with protocol details into the protocol.hpp and .cpp files
- Refactor `sweep_scan` / `sweep_device_accumulate_scans`  in anticipation of adding time stamps and turning it into a dynamically sized datastructure.  
