### PR TITLE
Fixed badly set bitrate causing sweep object creation to hang on Linux

### DIFF
--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -27,14 +27,10 @@ static speed_t get_baud(int32_t bitrate) {
     return -1;
   }
 
-  // translate human readable bitrate to termios bitrate
-  if (bitrate == 115200)
-  {
-    #ifdef B115200
-    bitrate = B115200;
-    #endif
-  }
-
+// translate human readable bitrate to termios bitrate
+#ifdef B115200
+  return B115200;
+#endif
   return bitrate;
 }
 
@@ -157,7 +153,7 @@ void device_read(device_s serial, void* to, int32_t len) {
         } else {
           throw error{"reading from serial device failed"};
         }
-      } else if(ret == 0){
+      } else if (ret == 0) {
         throw error{"encountered EOF on serial device"};
       } else {
         bytes_read += ret;

--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -26,6 +26,15 @@ static speed_t get_baud(int32_t bitrate) {
     throw error{"Only baud rate 115200 is supported at this time."};
     return -1;
   }
+
+  // translate human readable bitrate to termios bitrate
+  if (bitrate == 115200)
+  {
+    #ifdef B115200
+    bitrate = B115200;
+    #endif
+  }
+
   return bitrate;
 }
 


### PR DESCRIPTION
This bug was causing sweep object creation to hang when trying to read the returned value from serial port. ==> Issue #72

Bitrate of the serial communication was badly set during the creation of the sweep object when using the libsweep library on Linux.

cfsetispeed(...) and cfsetospeed(...) both take a termios bitrate constant and not the bitrate directly. So should the get_baud(115200) call return the B115200 value defined in termios.h.

The fix seems to have a limitation when compiling on some MAC OS X computers. Termios constants like B115200 doesn't seem to be always defined. That's why the code uses a #ifdef as a workaround for MAC.

Thanks.