### PR TITLE
[Sweeppy Docs] Clarify sample units and format in sweeppy README. 

### DIFF
--- a/libsweep/README.md
+++ b/libsweep/README.md
@@ -87,6 +87,7 @@ Table of Contents:
 - [Error Handling](#error-handling)
 - [Device Interaction](#device-interaction)
 - [Full 360 Degree Scan](#full-360-degree-scan)
+- [Additional Information](#additional-information)
 
 #### Firmware Compatibility
 | libsweep | sweep firmware |
@@ -306,6 +307,11 @@ int32_t sweep_scan_get_signal_strength(sweep_scan_s scan, int32_t sample)
 ```
 
 Returns the signal strength (0 low -- 255 high) for the `sample`th sample in the `sweep_scan_s`.
+
+
+#### Additional Information
+It is recommended that you read through the sweep [Theory of Operation](https://support.scanse.io/hc/en-us/articles/115006333327-Theory-of-Operation) and [Best Practices](https://support.scanse.io/hc/en-us/articles/115006055388-Best-Practices).
+
 
 ### License
 

--- a/sweeppy/README.md
+++ b/sweeppy/README.md
@@ -77,10 +77,31 @@ class Scan:
     self.samples -> Sample
 
 class Sample:
-    self.angle -> int
-    self.distance -> int
-    self.signal_strength -> int
+    self.angle -> int (milli-degree)
+    self.distance -> int (cm)
+    self.signal_strength -> int ([0:255])
 ```
+
+See the [libsweep README](https://github.com/scanse/sweep-sdk/tree/master/libsweep#device-interaction) for a description of how to use a related interface.
+
+Additionally, it is recommended that you read through the sweep [Theory of Operation](https://support.scanse.io/hc/en-us/articles/115006333327-Theory-of-Operation) and [Best Practices](https://support.scanse.io/hc/en-us/articles/115006055388-Best-Practices).
+
+### Interpret Sample
+```python
+sample.angle
+```
+The sample's angle (azimuth) represents the rotation of the sensor when the range measurment was taken. The value is reported in milli-degrees, or 1/1000 of a degree. For example, a `sample.angle` value of `180000 milli-degrees` equates to `180 degrees` (half of a complete rotation). Successive samples of the same scan will have increasing angles in the range 0-360000.
+
+```python
+sample.distance
+```
+The sample's distance is the range measurement (in cm).
+
+```python
+sample.distance
+```
+The sample's signal strength is the strength or confidence of the range measurement. The value is reported in the range 0-255, where larger values are better.
+
 
 ### License
 


### PR DESCRIPTION
We've been receiving quite  a few support messages from people confused by the output data format of the sweeppy example. Specifically, the milli-degree angle value is throwing people off. 

This is a quick patch the sweeppy README  that clarifies the format and units of the returned samples. 

Additionally, this PR updates the libsweep and sweeppy READMEs to include links to 2 articles on using the sweep (theory of operation and best practices).

We should probably also clarify the format and units in the libsweep and sweeppy examples.  Printing a simple header before printing the sample of gathered scans would go a long way.