### PR TITLE
character size must be set AFTER clearing character size bits

### DIFF
--- a/libsweep/src/unix/serial.cc
+++ b/libsweep/src/unix/serial.cc
@@ -95,8 +95,8 @@ device_s device_construct(const char* port, int32_t bitrate) {
   // IEXTEN
 
   // Control Flags
-  options.c_cflag |= (CLOCAL | CREAD | CS8);
   options.c_cflag &= ~(PARENB | CSTOPB | CSIZE);
+  options.c_cflag |= (CLOCAL | CREAD | CS8);
 
   // setup baud rate
   speed_t baud = get_baud(bitrate);


### PR DESCRIPTION
Fix another issue in Linux serial port configuration, which causes the issue #72 